### PR TITLE
e-relationalFromSql - helpers 2.0.0

### DIFF
--- a/e-relationalFromSql/BUILD.md
+++ b/e-relationalFromSql/BUILD.md
@@ -1,0 +1,23 @@
+###Build warning###
+As Oracle license does not allow to distribute Oracle JDBC driver and it is not published in any public 
+Maven repository (and it cannot be), one needs to manually install ojdbc7.jar into local Maven repository to be able to build this DPU.
+
+Oracle JDBC driver JAR (ojdbc7.jar) can be downloaded via Oracle site http://www.oracle.com/technetwork/database/features/jdbc/default-2280470.html
+
+This DPU uses 12.1.0.2.0 version. 
+
+To be able to build this DPU, this JAR must be either deployed to private artifactory or installed into local
+Maven repository via mvn install:install-file.
+In order to make build work without changes in pom, JAR must be depoloyed / installed with these values:
+
+|              |            |
+|--------------|------------|
+|group-id      |com.oracle  |
+|artifact-id   |ojdbc7      |
+|version       |12.1.0.2.0  |
+
+To install JAR to your local repository, use following command:
+
+	mvn install:install-file -Dfile=<dir>/ojdbc7.jar -DgroupId=com.oracle -DartifactId=ojdbc7 -Dversion=12.1.0.2.0 -Dpackaging=jar
+
+***

--- a/e-relationalFromSql/README.md
+++ b/e-relationalFromSql/README.md
@@ -77,7 +77,7 @@ To install JAR to your local repository, use following command:
 |Version          |Release notes                                                                                   |
 |-----------------|------------------------------------------------------------------------------------------------|
 |1.0.0            |New features, user-friendly GUI, support for MS SQL, Oracle, MySQL, Update for helpers 2.0.0    |
-|0.9.0-SNAPSHOT   |N/A                                                                                             |
+| 0.9.0   | Version for evaluation, compatible with API v1.3.0                                                                                             |
 
 
 ***

--- a/e-relationalFromSql/README.md
+++ b/e-relationalFromSql/README.md
@@ -76,6 +76,7 @@ To install JAR to your local repository, use following command:
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
+|1.0.1-SNAPSHOT   |Update for helpers 2.0.0    |
 |1.0.0-SNAPSHOT   |N/A                         |
 
 

--- a/e-relationalFromSql/README.md
+++ b/e-relationalFromSql/README.md
@@ -1,30 +1,6 @@
 # E-RelationalFromSql #
 ----------
 
-###Build warning###
-As Oracle license does not allow to distribute Oracle JDBC driver and it is not published in any public 
-Maven repository (and it cannot be), one needs to manually install ojdbc7.jar into local Maven repository to be able to build this DPU.
-
-Oracle JDBC driver JAR (ojdbc7.jar) can be downloaded via Oracle site http://www.oracle.com/technetwork/database/features/jdbc/default-2280470.html
-
-This DPU uses 12.1.0.2.0 version. 
-
-To be able to build this DPU, this JAR must be either deployed to private artifactory or installed into local
-Maven repository via mvn install:install-file.
-In order to make build work without changes in pom, JAR must be depoloyed / installed with these values:
-
-|              |            |
-|--------------|------------|
-|group-id      |com.oracle  |
-|artifact-id   |ojdbc7      |
-|version       |12.1.0.2.0  |
-
-To install JAR to your local repository, use following command:
-
-	mvn install:install-file -Dfile=<dir>/ojdbc7.jar -DgroupId=com.oracle -DartifactId=ojdbc7 -Dversion=12.1.0.2.0 -Dpackaging=jar
-
-***
-
 ###General###
 
 |                              |                                                                             |
@@ -86,4 +62,4 @@ To install JAR to your local repository, use following command:
 
 |Author           |Notes                           |
 |-----------------|--------------------------------|
-|N/A              |N/A                             | 
+|eea03            |Manual steps are required to build this project, see [build info](BUILD.md)    | 

--- a/e-relationalFromSql/README.md
+++ b/e-relationalFromSql/README.md
@@ -74,10 +74,10 @@ To install JAR to your local repository, use following command:
 
 ### Version history ###
 
-|Version          |Release notes               |
-|-----------------|----------------------------|
-|1.0.1-SNAPSHOT   |Update for helpers 2.0.0    |
-|1.0.0-SNAPSHOT   |N/A                         |
+|Version          |Release notes                                                                                   |
+|-----------------|------------------------------------------------------------------------------------------------|
+|1.0.0            |New features, user-friendly GUI, support for MS SQL, Oracle, MySQL, Update for helpers 2.0.0    |
+|0.9.0-SNAPSHOT   |N/A                                                                                             |
 
 
 ***

--- a/e-relationalFromSql/pom.xml
+++ b/e-relationalFromSql/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-        <groupId>eu.unifiedviews</groupId>
-        <artifactId>uv-pom-dpu</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+		<groupId>eu.unifiedviews</groupId>
+		<artifactId>uv-pom-dpu</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -17,11 +18,11 @@
 	<properties>
 		<dpu.package>eu.unifiedviews.plugins.extractor.relationalfromsql</dpu.package>
 		<dpu.mainClass>RelationalFromSql</dpu.mainClass>
-        <uv.helpers.version>[2.0.0-SNAPSHOT,3.0.0)</uv.helpers.version>
+		<uv.helpers.version>[2.0.0-SNAPSHOT,3.0.0)</uv.helpers.version>
 		<mockito.version>1.10.8</mockito.version>
 		<powermock.version>1.6.1</powermock.version>
 		<junit.version>4.12</junit.version>
-        <module-test.version>2.0.0-SNAPSHOT</module-test.version>
+		<module-test.version>2.0.0-SNAPSHOT</module-test.version>
 		<embed.transitive>true</embed.transitive>
 		<osgi.import.package>!com.sun.jdi.*,!com.sun.msv.*,!com.sun.org.apache.xerces.*,!org.jboss.*,!org.jdom,!org.jdom.input,!org.relaxng.datatype,!sun.io,!com.sun.security.*,!oracle.i18n.*,!oracle.ons,!oracle.security.pki,!oracle.xdb,!oracle.xml.*,!org.apache.log4j,!org.objectweb.asm,!sun.security.*,!com.oracle.common.*,!com.sun.jna.*,!waffle.windows.auth.*,*</osgi.import.package>
 	</properties>
@@ -123,31 +124,31 @@
 			<version>1.2</version>
 		</dependency>
 
-        <!-- UnifiedViews helpers. -->
+		<!-- UnifiedViews helpers. -->
 
-        <dependency>
-            <groupId>eu.unifiedviews</groupId>
-            <artifactId>uv-dataunit-helpers</artifactId>
-            <version>${uv.helpers.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>eu.unifiedviews</groupId>
-            <artifactId>uv-dpu-helpers</artifactId>
-            <version>${uv.helpers.version}</version>
-            <scope>compile</scope>
-        </dependency>
+		<dependency>
+			<groupId>eu.unifiedviews</groupId>
+			<artifactId>uv-dataunit-helpers</artifactId>
+			<version>${uv.helpers.version}</version>
+			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>eu.unifiedviews</groupId>
+			<artifactId>uv-dpu-helpers</artifactId>
+			<version>${uv.helpers.version}</version>
+			<scope>compile</scope>
+		</dependency>
 
 		<!-- Core UnifiedViews testing support. -->
-        <dependency>
-            <groupId>cz.cuni.mff.xrg.odcs</groupId>
-            <artifactId>module-test</artifactId>
-            <version>${module-test.version}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>cz.cuni.mff.xrg.odcs</groupId>
+			<artifactId>module-test</artifactId>
+			<version>${module-test.version}</version>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- JUnit tests dependencies -->
+		<!-- JUnit tests dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/e-relationalFromSql/pom.xml
+++ b/e-relationalFromSql/pom.xml
@@ -1,15 +1,15 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>eu.unifiedviews.plugins</groupId>
-		<artifactId>dpu-base-pom</artifactId>
-		<version>1.3.0</version>
+        <groupId>eu.unifiedviews</groupId>
+        <artifactId>uv-pom-dpu</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<artifactId>uv-e-relationalFromSql</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>E-RelationalFromSql</name>
 	<description>Extracts data from relational database using SQL queries and stores them into internal data unit relational database</description>
@@ -17,9 +17,11 @@
 	<properties>
 		<dpu.package>eu.unifiedviews.plugins.extractor.relationalfromsql</dpu.package>
 		<dpu.mainClass>RelationalFromSql</dpu.mainClass>
+        <uv.helpers.version>[2.0.0-SNAPSHOT,3.0.0)</uv.helpers.version>
 		<mockito.version>1.10.8</mockito.version>
 		<powermock.version>1.6.1</powermock.version>
 		<junit.version>4.12</junit.version>
+        <module-test.version>2.0.0-SNAPSHOT</module-test.version>
 		<embed.transitive>true</embed.transitive>
 		<import.package>!com.sun.jdi.*,!com.sun.msv.*,!com.sun.org.apache.xerces.*,!org.jboss.*,!org.jdom,!org.jdom.input,!org.relaxng.datatype,!sun.io,!sun.misc,!com.sun.security.*,!oracle.i18n.*,!oracle.ons,!oracle.security.pki,!oracle.xdb,!oracle.xml.parser.v2,!org.apache.log4j,!org.objectweb.asm,!sun.security.*,*</import.package>
 	</properties>
@@ -127,15 +129,31 @@
 			<version>1.2</version>
 		</dependency>
 
+        <!-- UnifiedViews helpers. -->
 
-		<!-- JUnit tests dependencies -->
-		<dependency>
-			<groupId>cz.cuni.mff.xrg.odcs</groupId>
-			<artifactId>module-test</artifactId>
-			<version>${module-test.version}</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>eu.unifiedviews</groupId>
+            <artifactId>uv-dataunit-helpers</artifactId>
+            <version>${uv.helpers.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>eu.unifiedviews</groupId>
+            <artifactId>uv-dpu-helpers</artifactId>
+            <version>${uv.helpers.version}</version>
+            <scope>compile</scope>
+        </dependency>
 
+		<!-- Core UnifiedViews testing support. -->
+        <dependency>
+            <groupId>cz.cuni.mff.xrg.odcs</groupId>
+            <artifactId>module-test</artifactId>
+            <version>${module-test.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- JUnit tests dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/e-relationalFromSql/pom.xml
+++ b/e-relationalFromSql/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>uv-e-relationalFromSql</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>E-RelationalFromSql</name>
 	<description>Extracts data from relational database using SQL queries and stores them into internal data unit relational database</description>
@@ -23,7 +23,7 @@
 		<junit.version>4.12</junit.version>
         <module-test.version>2.0.0-SNAPSHOT</module-test.version>
 		<embed.transitive>true</embed.transitive>
-		<import.package>!com.sun.jdi.*,!com.sun.msv.*,!com.sun.org.apache.xerces.*,!org.jboss.*,!org.jdom,!org.jdom.input,!org.relaxng.datatype,!sun.io,!sun.misc,!com.sun.security.*,!oracle.i18n.*,!oracle.ons,!oracle.security.pki,!oracle.xdb,!oracle.xml.parser.v2,!org.apache.log4j,!org.objectweb.asm,!sun.security.*,*</import.package>
+		<osgi.import.package>!com.sun.jdi.*,!com.sun.msv.*,!com.sun.org.apache.xerces.*,!org.jboss.*,!org.jdom,!org.jdom.input,!org.relaxng.datatype,!sun.io,!com.sun.security.*,!oracle.i18n.*,!oracle.ons,!oracle.security.pki,!oracle.xdb,!oracle.xml.*,!org.apache.log4j,!org.objectweb.asm,!sun.security.*,!com.oracle.common.*,!com.sun.jna.*,!waffle.windows.auth.*,*</osgi.import.package>
 	</properties>
 
 	<dependencies>
@@ -118,12 +118,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>xerces</groupId>
-			<artifactId>xercesImpl</artifactId>
-			<version>2.11.0</version>
-		</dependency>
-
-		<dependency>
 			<groupId>xml-resolver</groupId>
 			<artifactId>xml-resolver</artifactId>
 			<version>1.2</version>
@@ -193,16 +187,5 @@
 			<url>http://maven.eea.sk/artifactory/public/</url>
 		</repository>
 	</repositories>
-
-	<build>
-		<resources>
-			<resource>
-				<directory>src/main/resources</directory>
-				<includes>
-					<include>resources*.properties</include>
-				</includes>
-			</resource>
-		</resources>
-	</build>
 
 </project>

--- a/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSql.java
+++ b/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSql.java
@@ -19,12 +19,14 @@ import eu.unifiedviews.dataunit.relational.WritableRelationalDataUnit;
 import eu.unifiedviews.dpu.DPU;
 import eu.unifiedviews.dpu.DPUContext;
 import eu.unifiedviews.dpu.DPUException;
-import eu.unifiedviews.helpers.dataunit.resourcehelper.Resource;
-import eu.unifiedviews.helpers.dataunit.resourcehelper.ResourceHelpers;
-import eu.unifiedviews.helpers.dpu.config.AbstractConfigDialog;
-import eu.unifiedviews.helpers.dpu.config.ConfigDialogProvider;
-import eu.unifiedviews.helpers.dpu.config.ConfigurableBase;
-import eu.unifiedviews.helpers.dpu.localization.Messages;
+import eu.unifiedviews.helpers.dataunit.resource.Resource;
+import eu.unifiedviews.helpers.dataunit.resource.ResourceHelpers;
+import eu.unifiedviews.helpers.dpu.config.ConfigHistory;
+import eu.unifiedviews.helpers.dpu.config.migration.ConfigurationUpdate;
+import eu.unifiedviews.helpers.dpu.context.ContextUtils;
+import eu.unifiedviews.helpers.dpu.exec.AbstractDpu;
+import eu.unifiedviews.helpers.dpu.extension.ExtensionInitializer;
+import eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultTolerance;
 
 /**
  * {@link RelationalFromSql} extracts data from external source relational database (currently PostgreSQL supported)
@@ -44,25 +46,27 @@ import eu.unifiedviews.helpers.dpu.localization.Messages;
  * future releases.
  */
 @DPU.AsExtractor
-public class RelationalFromSql extends ConfigurableBase<RelationalFromSqlConfig_V2> implements ConfigDialogProvider<RelationalFromSqlConfig_V2> {
+public class RelationalFromSql extends AbstractDpu<RelationalFromSqlConfig_V2> {
 
     private static final Logger LOG = LoggerFactory.getLogger(RelationalFromSql.class);
-
-    private Messages messages;
 
     private DPUContext context;
 
     @DataUnit.AsOutput(name = "outputTables")
     public WritableRelationalDataUnit outputTables;
 
+    @ExtensionInitializer.Init
+    public FaultTolerance faultTolerance;
+
+    @ExtensionInitializer.Init(param = "eu.unifiedviews.plugins.extractor.relationalfromsql.RelationalFromSqlConfig__V2")
+    public ConfigurationUpdate _ConfigurationUpdate;
+
     public RelationalFromSql() {
-        super(RelationalFromSqlConfig_V2.class);
+        super(RelationalFromSqlVaadinDialog.class, ConfigHistory.noHistory(RelationalFromSqlConfig_V2.class));
     }
 
     @Override
-    public void execute(DPUContext context) throws DPUException, InterruptedException {
-        this.context = context;
-        this.messages = new Messages(this.context.getLocale(), this.getClass().getClassLoader());
+    protected void innerExecute() throws DPUException {
         String shortMessage = this.getClass().getSimpleName() + " starting.";
         String longMessage = String.format("Configuration: DatabaseHost: %s, username: %s, password: %s, "
                 + "useSSL: %s, SQL query: %s",
@@ -73,7 +77,7 @@ public class RelationalFromSql extends ConfigurableBase<RelationalFromSqlConfig_
         try {
             Class.forName(SqlDatabase.getJdbcDriverNameForDatabase(this.config.getDatabaseType()));
         } catch (ClassNotFoundException e) {
-            throw new DPUException(this.messages.getString("errors.driver.loadfailed"), e);
+            throw ContextUtils.dpuException(ctx, e, "errors.driver.loadfailed");
         }
 
         Connection conn = null;
@@ -83,16 +87,16 @@ public class RelationalFromSql extends ConfigurableBase<RelationalFromSqlConfig_
 
         try {
             String tableName = this.config.getTargetTableName().toUpperCase();
-            String symbolicName = tableName;
+            final String symbolicName = tableName;
 
             try {
                 if (checkInternalTableExists(tableName)) {
-                    this.context.sendMessage(DPUContext.MessageType.ERROR, this.messages.getString("errors.db.tableunique.short", tableName),
-                            this.messages.getString("errors.db.tableunique.long"));
+                    this.context.sendMessage(DPUContext.MessageType.ERROR, ctx.tr("errors.db.tableunique.short", tableName),
+                            ctx.tr("errors.db.tableunique.long"));
                     return;
                 }
             } catch (SQLException | DataUnitException e) {
-                throw new DPUException(this.messages.getString("errors.db.internaltable"));
+                throw ContextUtils.dpuException(ctx, "errors.db.internaltable");
             }
 
             try {
@@ -100,7 +104,7 @@ public class RelationalFromSql extends ConfigurableBase<RelationalFromSqlConfig_
                 conn = RelationalFromSqlHelper.createConnection(this.config);
                 LOG.debug("Connected to the source database");
             } catch (SQLException e) {
-                throw new DPUException(this.messages.getString("errors.db.connectionfailed"), e);
+                throw ContextUtils.dpuException(ctx, e, "errors.db.connectionfailed");
             }
 
             try {
@@ -109,7 +113,7 @@ public class RelationalFromSql extends ConfigurableBase<RelationalFromSqlConfig_
                 rs = stmnt.executeQuery(this.config.getSqlQuery());
                 meta = rs.getMetaData();
             } catch (SQLException e) {
-                throw new DPUException(this.messages.getString("errors.db.queryfailed"), e);
+                throw ContextUtils.dpuException(ctx, e, "errors.db.queryfailed");
             }
 
             try {
@@ -147,14 +151,20 @@ public class RelationalFromSql extends ConfigurableBase<RelationalFromSqlConfig_
                     LOG.debug("Indexes created successfully");
                 }
 
-                Resource resource = ResourceHelpers.getResource(this.outputTables, symbolicName);
-                Date now = new Date();
-                resource.setCreated(now);
-                resource.setLast_modified(now);
-                ResourceHelpers.setResource(this.outputTables, symbolicName, resource);
+                faultTolerance.execute(new FaultTolerance.Action() {
+
+                    @Override
+                    public void action() throws Exception {
+                        Resource resource = ResourceHelpers.getResource(outputTables, symbolicName);
+                        Date now = new Date();
+                        resource.setCreated(now);
+                        resource.setLast_modified(now);
+                        ResourceHelpers.setResource(outputTables, symbolicName, resource);
+                    }
+                });
                 LOG.debug("Resource parameters for table updated");
             } catch (Exception e) {
-                throw new DPUException(this.messages.getString("errors.db.transformfailed"), e);
+                throw ContextUtils.dpuException(ctx, e, "errors.db.transformfailed");
             }
         } finally {
             RelationalFromSqlHelper.tryCloseDbResources(conn, stmnt, rs);
@@ -232,11 +242,6 @@ public class RelationalFromSql extends ConfigurableBase<RelationalFromSqlConfig_
 
     private Connection getConnectionInternal() throws DataUnitException {
         return this.outputTables.getDatabaseConnection();
-    }
-
-    @Override
-    public AbstractConfigDialog<RelationalFromSqlConfig_V2> getConfigurationDialog() {
-        return new RelationalFromSqlVaadinDialog();
     }
 
 }

--- a/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlVaadinDialog.java
+++ b/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlVaadinDialog.java
@@ -70,7 +70,7 @@ public class RelationalFromSqlVaadinDialog extends AbstractDialog<RelationalFrom
         this.mainLayout.setWidth("100%");
         this.mainLayout.setHeight("-1px");
         this.mainLayout.setSpacing(true);
-        this.mainLayout.setMargin(false);
+        this.mainLayout.setMargin(true);
 
         this.databaseType = new NativeSelect();
         this.databaseType.setCaption(ctx.tr("dialog.extractdb.dbtype"));

--- a/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlVaadinDialog.java
+++ b/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlVaadinDialog.java
@@ -13,16 +13,12 @@ import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.Button.ClickListener;
 
 import eu.unifiedviews.dpu.config.DPUConfigException;
-import eu.unifiedviews.helpers.dpu.config.BaseConfigDialog;
-import eu.unifiedviews.helpers.dpu.config.InitializableConfigDialog;
-import eu.unifiedviews.helpers.dpu.localization.Messages;
+import eu.unifiedviews.helpers.dpu.vaadin.dialog.AbstractDialog;
 import eu.unifiedviews.plugins.extractor.relationalfromsql.SqlDatabase.DatabaseType;
 
-public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFromSqlConfig_V2> implements InitializableConfigDialog {
+public class RelationalFromSqlVaadinDialog extends AbstractDialog<RelationalFromSqlConfig_V2> {
 
     private static final long serialVersionUID = -6978431151165728797L;
-
-    private Messages messages;
 
     private VerticalLayout mainLayout;
 
@@ -61,13 +57,11 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
     private Button btnCreateQuery;
 
     public RelationalFromSqlVaadinDialog() {
-        super(RelationalFromSqlConfig_V2.class);
+        super(RelationalFromSql.class);
     }
 
     @Override
-    public void initialize() {
-        this.messages = new Messages(getContext().getLocale(), this.getClass().getClassLoader());
-
+    protected void buildDialogLayout() {
         setWidth("100%");
         setHeight("100%");
 
@@ -79,7 +73,7 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
         this.mainLayout.setMargin(false);
 
         this.databaseType = new NativeSelect();
-        this.databaseType.setCaption(this.messages.getString("dialog.extractdb.dbtype"));
+        this.databaseType.setCaption(ctx.tr("dialog.extractdb.dbtype"));
         this.databaseType.addItems(SqlDatabase.getDatabaseTypeNames());
         this.databaseType.setNullSelectionAllowed(false);
         this.databaseType.setImmediate(true);
@@ -89,94 +83,94 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
         this.mainLayout.addComponent(this.databaseType);
 
         this.txtDatabaseHost = new TextField();
-        this.txtDatabaseHost.setCaption(this.messages.getString("dialog.extractdb.dbhost"));
+        this.txtDatabaseHost.setCaption(ctx.tr("dialog.extractdb.dbhost"));
         this.txtDatabaseHost.setRequired(true);
         this.txtDatabaseHost.setNullRepresentation("");
         this.txtDatabaseHost.setWidth("100%");
         this.mainLayout.addComponent(this.txtDatabaseHost);
 
         this.txtDatabasePort = new TextField();
-        this.txtDatabasePort.setCaption(this.messages.getString("dialog.extractdb.dbport"));
+        this.txtDatabasePort.setCaption(ctx.tr("dialog.extractdb.dbport"));
         this.txtDatabasePort.setRequired(true);
         this.txtDatabasePort.setWidth("100%");
         this.mainLayout.addComponent(this.txtDatabasePort);
 
         this.txtDatabaseName = new TextField();
-        this.txtDatabaseName.setCaption(this.messages.getString("dialog.extractdb.dbname"));
+        this.txtDatabaseName.setCaption(ctx.tr("dialog.extractdb.dbname"));
         this.txtDatabaseName.setRequired(true);
         this.txtDatabaseName.setNullRepresentation("");
         this.txtDatabaseName.setWidth("100%");
         this.mainLayout.addComponent(this.txtDatabaseName);
 
         this.txtInstanceName = new TextField();
-        this.txtInstanceName.setCaption(this.messages.getString("dialog.extractdb.instance"));
+        this.txtInstanceName.setCaption(ctx.tr("dialog.extractdb.instance"));
         this.txtInstanceName.setNullRepresentation("");
         this.txtInstanceName.setWidth("100%");
         this.txtInstanceName.setVisible(false);
         this.mainLayout.addComponent(this.txtInstanceName);
 
         this.txtUserName = new TextField();
-        this.txtUserName.setCaption(this.messages.getString("dialog.extractdb.username"));
+        this.txtUserName.setCaption(ctx.tr("dialog.extractdb.username"));
         this.txtUserName.setRequired(true);
         this.txtUserName.setNullRepresentation("");
         this.txtUserName.setWidth("100%");
         this.mainLayout.addComponent(this.txtUserName);
 
         this.txtPassword = new PasswordField();
-        this.txtPassword.setCaption(this.messages.getString("dialog.extractdb.password"));
+        this.txtPassword.setCaption(ctx.tr("dialog.extractdb.password"));
         this.txtPassword.setRequired(true);
         this.txtPassword.setNullRepresentation("");
         this.txtPassword.setWidth("100%");
         this.mainLayout.addComponent(this.txtPassword);
 
         this.chckUseSsl = new CheckBox();
-        this.chckUseSsl.setCaption(this.messages.getString("dialog.extractdb.usessl"));
+        this.chckUseSsl.setCaption(ctx.tr("dialog.extractdb.usessl"));
         this.chckUseSsl.addValueChangeListener(createSslValueChangeListener());
         this.mainLayout.addComponent(this.chckUseSsl);
 
         this.txtTruststoreLocation = new TextField();
-        this.txtTruststoreLocation.setCaption(this.messages.getString("dialog.extractdb.truststore.location"));
-        this.txtTruststoreLocation.setDescription(this.messages.getString("dialog.extractdb.truststore"));
+        this.txtTruststoreLocation.setCaption(ctx.tr("dialog.extractdb.truststore.location"));
+        this.txtTruststoreLocation.setDescription(ctx.tr("dialog.extractdb.truststore"));
         this.txtTruststoreLocation.setVisible(false);
         this.txtTruststoreLocation.setNullRepresentation("");
         this.txtTruststoreLocation.setWidth("100%");
         this.mainLayout.addComponent(this.txtTruststoreLocation);
 
         this.txtTruststorePassword = new PasswordField();
-        this.txtTruststorePassword.setCaption(this.messages.getString("dialog.extractdb.truststore.password"));
+        this.txtTruststorePassword.setCaption(ctx.tr("dialog.extractdb.truststore.password"));
         this.txtTruststorePassword.setNullRepresentation("");
         this.txtTruststorePassword.setWidth("100%");
         this.txtTruststorePassword.setVisible(false);
         this.mainLayout.addComponent(this.txtTruststorePassword);
 
         this.btntestConnection = new Button();
-        this.btntestConnection.setCaption(this.messages.getString("dialog.extractdb.testdb"));
+        this.btntestConnection.setCaption(ctx.tr("dialog.extractdb.testdb"));
         this.btntestConnection.addClickListener(createTestClickListener());
         this.mainLayout.addComponent(this.btntestConnection);
 
         this.txtTargetTableName = new TextField();
-        this.txtTargetTableName.setCaption(this.messages.getString("dialog.extractdb.targettable"));
-        this.txtTargetTableName.setDescription(this.messages.getString("dialog.extractdb.tabledescr"));
+        this.txtTargetTableName.setCaption(ctx.tr("dialog.extractdb.targettable"));
+        this.txtTargetTableName.setDescription(ctx.tr("dialog.extractdb.tabledescr"));
         this.txtTargetTableName.setRequired(true);
         this.txtTargetTableName.setNullRepresentation("");
         this.txtTargetTableName.setWidth("100%");
         this.mainLayout.addComponent(this.txtTargetTableName);
 
         this.txtSqlQuery = new TextArea();
-        this.txtSqlQuery.setCaption(this.messages.getString("dialog.extractdb.query"));
+        this.txtSqlQuery.setCaption(ctx.tr("dialog.extractdb.query"));
         this.txtSqlQuery.setRequired(true);
         this.txtSqlQuery.setNullRepresentation("");
         this.txtSqlQuery.setWidth("100%");
         this.txtSqlQuery.setHeight("125px");
-        this.txtSqlQuery.setInputPrompt(this.messages.getString("dialog.extractdb.query.prompt"));
+        this.txtSqlQuery.setInputPrompt(ctx.tr("dialog.extractdb.query.prompt"));
         this.mainLayout.addComponent(this.txtSqlQuery);
 
         this.btnPreview = new Button();
-        this.btnPreview.setCaption(this.messages.getString("dialog.extractdb.preview"));
+        this.btnPreview.setCaption(ctx.tr("dialog.extractdb.preview"));
         this.btnPreview.addClickListener(createPreviewInitListener());
 
         this.btnCreateQuery = new Button();
-        this.btnCreateQuery.setCaption(this.messages.getString("dialog.extractdb.createquery"));
+        this.btnCreateQuery.setCaption(ctx.tr("dialog.extractdb.createquery"));
         this.btnCreateQuery.addClickListener(createSelectQueryListener());
 
         HorizontalLayout queryButtons = new HorizontalLayout();
@@ -186,15 +180,15 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
         this.mainLayout.addComponent(queryButtons);
 
         this.txtPrimaryKeys = new TextField();
-        this.txtPrimaryKeys.setCaption(this.messages.getString("dialog.extractdb.keys"));
-        this.txtPrimaryKeys.setDescription(this.messages.getString("dialog.extractdb.keysdescr"));
+        this.txtPrimaryKeys.setCaption(ctx.tr("dialog.extractdb.keys"));
+        this.txtPrimaryKeys.setDescription(ctx.tr("dialog.extractdb.keysdescr"));
         this.txtPrimaryKeys.setNullRepresentation("");
         this.txtPrimaryKeys.setWidth("100%");
         this.mainLayout.addComponent(this.txtPrimaryKeys);
 
         this.txtIndexes = new TextField();
-        this.txtIndexes.setCaption(this.messages.getString("dialog.extractdb.indexes"));
-        this.txtIndexes.setDescription(this.messages.getString("dialog.extractdb.indexdescr"));
+        this.txtIndexes.setCaption(ctx.tr("dialog.extractdb.indexes"));
+        this.txtIndexes.setDescription(ctx.tr("dialog.extractdb.indexdescr"));
         this.txtIndexes.setNullRepresentation("");
         this.txtIndexes.setWidth("100%");
         this.mainLayout.addComponent(this.txtIndexes);
@@ -223,9 +217,9 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
                 DatabaseType dbType = SqlDatabase.getDatabaseTypeForDatabaseName(databaseName);
                 txtDatabasePort.setValue(String.valueOf(portForSelectedDbType));
                 if (dbType == DatabaseType.ORACLE) {
-                    txtDatabaseName.setCaption(messages.getString("dialog.extractdb.dbsid"));
+                    txtDatabaseName.setCaption(ctx.tr("dialog.extractdb.dbsid"));
                 } else {
-                    txtDatabaseName.setCaption(messages.getString("dialog.extractdb.dbname"));
+                    txtDatabaseName.setCaption(ctx.tr("dialog.extractdb.dbname"));
                 }
 
                 if (dbType == DatabaseType.MSSQL) {
@@ -272,12 +266,12 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
                     boolean bTestResult = true;
                     bTestResult = RelationalFromSqlHelper.testDatabaseConnection(getConfigurationInternal());
                     if (bTestResult) {
-                        showMessage("dialog.messages.testsuccess", Notification.Type.HUMANIZED_MESSAGE);
+                        showMessage("dialog.ctx.testsuccess", Notification.Type.HUMANIZED_MESSAGE);
                     } else {
-                        showMessage("dialog.messages.testfail", Notification.Type.ERROR_MESSAGE);
+                        showMessage("dialog.ctx.testfail", Notification.Type.ERROR_MESSAGE);
                     }
                 } else {
-                    showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
+                    showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
                 }
             }
         };
@@ -286,7 +280,7 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
     }
 
     private void showMessage(String messageResource, Notification.Type type) {
-        Notification notification = new Notification(this.messages.getString(messageResource), type);
+        Notification notification = new Notification(ctx.tr(messageResource), type);
         notification.show(Page.getCurrent());
     }
 
@@ -307,7 +301,7 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
                         UI.getCurrent().addWindow(tablesWindow);
                     }
                 } else {
-                    showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
+                    showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
                 }
             }
         };
@@ -329,7 +323,7 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
                     Window previewInit = createPreviewWindow();
                     UI.getCurrent().addWindow(previewInit);
                 } else {
-                    showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
+                    showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
                 }
             }
         };
@@ -359,13 +353,13 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
             showMessage("dialog.errors.select.tables", Notification.Type.ERROR_MESSAGE);
             return null;
         }
-        final ListSelect tableSelect = new ListSelect(this.messages.getString("dialog.extractdb.tables"), tables);
+        final ListSelect tableSelect = new ListSelect(ctx.tr("dialog.extractdb.tables"), tables);
         tableSelect.setRows(7);
         tableSelect.setNullSelectionAllowed(false);
         layout.addComponent(tableSelect);
 
         Button btnClose = new Button();
-        btnClose.setCaption(this.messages.getString("dialog.extractdb.close"));
+        btnClose.setCaption(ctx.tr("dialog.extractdb.close"));
         btnClose.addClickListener(new ClickListener() {
 
             private static final long serialVersionUID = 1L;
@@ -377,7 +371,7 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
         });
 
         Button btnCreate = new Button();
-        btnCreate.setCaption(this.messages.getString("dialog.extractdb.createsql"));
+        btnCreate.setCaption(ctx.tr("dialog.extractdb.createsql"));
         btnCreate.addClickListener(new ClickListener() {
 
             private static final long serialVersionUID = 1L;
@@ -391,7 +385,7 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
                         String query = RelationalFromSqlHelper.generateSelectForTable(table, tableColumns);
                         RelationalFromSqlVaadinDialog.this.txtSqlQuery.setValue(query);
                     } else {
-                        showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
+                        showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
                     }
                 } catch (SQLException e) {
                     showMessage("dialog.errors.select.query", Notification.Type.ERROR_MESSAGE);
@@ -425,14 +419,14 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
         layout.setHeight("-1px");
 
         final TextField txtLimit = new TextField();
-        txtLimit.setCaption(this.messages.getString("dialog.preview.limit"));
+        txtLimit.setCaption(ctx.tr("dialog.preview.limit"));
         txtLimit.setWidth("100%");
         txtLimit.setValue("100");
         txtLimit.addValidator(createSelectLimitValidator());
         layout.addComponent(txtLimit);
 
         Button btnPreview = new Button();
-        btnPreview.setCaption(this.messages.getString("dialog.extractdb.preview"));
+        btnPreview.setCaption(ctx.tr("dialog.extractdb.preview"));
         btnPreview.addClickListener(new ClickListener() {
 
             private static final long serialVersionUID = 1L;
@@ -472,10 +466,10 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
                 try {
                     limit = Integer.parseInt((String) value);
                 } catch (NumberFormatException e) {
-                    throw new InvalidValueException(messages.getString("dialog.errors.limit"));
+                    throw new InvalidValueException(ctx.tr("dialog.errors.limit"));
                 }
                 if (limit < 1 || limit > 10000) {
-                    throw new InvalidValueException(messages.getString("dialog.errors.limit"));
+                    throw new InvalidValueException(ctx.tr("dialog.errors.limit"));
                 }
             }
         };
@@ -576,7 +570,7 @@ public class RelationalFromSqlVaadinDialog extends BaseConfigDialog<RelationalFr
             isValid = isValid && this.txtInstanceName.isValid();
         }
         if (!isValid) {
-            throw new DPUConfigException(this.messages.getString("dialog.errors.params"));
+            throw new DPUConfigException(ctx.tr("dialog.errors.params"));
         }
 
         RelationalFromSqlConfig_V2 config = new RelationalFromSqlConfig_V2();

--- a/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlVaadinDialog.java
+++ b/e-relationalFromSql/src/main/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlVaadinDialog.java
@@ -266,12 +266,12 @@ public class RelationalFromSqlVaadinDialog extends AbstractDialog<RelationalFrom
                     boolean bTestResult = true;
                     bTestResult = RelationalFromSqlHelper.testDatabaseConnection(getConfigurationInternal());
                     if (bTestResult) {
-                        showMessage("dialog.ctx.testsuccess", Notification.Type.HUMANIZED_MESSAGE);
+                        showMessage("dialog.messages.testsuccess", Notification.Type.HUMANIZED_MESSAGE);
                     } else {
-                        showMessage("dialog.ctx.testfail", Notification.Type.ERROR_MESSAGE);
+                        showMessage("dialog.messages.testfail", Notification.Type.ERROR_MESSAGE);
                     }
                 } else {
-                    showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
+                    showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
                 }
             }
         };
@@ -301,7 +301,7 @@ public class RelationalFromSqlVaadinDialog extends AbstractDialog<RelationalFrom
                         UI.getCurrent().addWindow(tablesWindow);
                     }
                 } else {
-                    showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
+                    showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
                 }
             }
         };
@@ -323,7 +323,7 @@ public class RelationalFromSqlVaadinDialog extends AbstractDialog<RelationalFrom
                     Window previewInit = createPreviewWindow();
                     UI.getCurrent().addWindow(previewInit);
                 } else {
-                    showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
+                    showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
                 }
             }
         };
@@ -385,7 +385,7 @@ public class RelationalFromSqlVaadinDialog extends AbstractDialog<RelationalFrom
                         String query = RelationalFromSqlHelper.generateSelectForTable(table, tableColumns);
                         RelationalFromSqlVaadinDialog.this.txtSqlQuery.setValue(query);
                     } else {
-                        showMessage("dialog.ctx.dbparams", Notification.Type.WARNING_MESSAGE);
+                        showMessage("dialog.messages.dbparams", Notification.Type.WARNING_MESSAGE);
                     }
                 } catch (SQLException e) {
                     showMessage("dialog.errors.select.query", Notification.Type.ERROR_MESSAGE);

--- a/e-relationalFromSql/src/main/resources/about.html
+++ b/e-relationalFromSql/src/main/resources/about.html
@@ -1,0 +1,1 @@
+Extracts data from relational database using SQL queries and stores them into internal data unit relational database.

--- a/e-relationalFromSql/src/main/resources/about.html
+++ b/e-relationalFromSql/src/main/resources/about.html
@@ -1,1 +1,28 @@
-Extracts data from relational database using SQL queries and stores them into internal data unit relational database.
+<b>E-RelationalFromSql</b> can be used to extract data from relational database using SQL queries and stores them into internal data unit relational database.
+<br/>This DPU provides some features for extracting from database: list of tables in database, generating SELECT for selected table, data preview
+<br/>Secured connection to source database via SSL is supported
+<p/>DPU currently supports these databases:
+<ul>
+	<li>PostgreSQL</li>
+	<li>Oracle</li>
+	<li>MySQL</li>
+	<li>Microsoft SQL</li>
+</ul>
+
+<p/>Configuration options:
+<ul>
+	<li><b>Database type</b> - Database type: PostgreSQL, Oracle, MySQL, MS SQL</li>
+	<li><b>Database host</b> - Database host (URL or IP), e.g. localhost</li>
+	<li><b>Database port</b> - Database port, default are filled automatically</li>
+	<li><b>Database name / SID</b> - Database name or for ORACLE database SID</li>
+	<li><b>Instance name</b> (optional) - Only for MS SQL, instance name of server</li>
+	<li><b>User name</b> - User name</li>
+	<li><b>User password</b> - Password</li>
+	<li><b>Connect via SSL</b> - Use secured SSL connection to connect to database</li>
+	<li><b>Truststore location</b> (optional) - Path to truststore file to be used to validate server's certificate. If not filled, default Java truststore is used</li>
+	<li><b>Truststore password</b> (optional) - Truststore password</li>
+	<li><b>SQL query</b> - SELECT SQL query</li>
+	<li><b>Target table name</b> - Table name used to internally store the extracted data</li>
+	<li><b>Primary key columns</b> (optional) - Target table primary key</li>	
+	<li><b>Indexed columns</b> (optional) - Target table indexed columns</li>
+</ul> 

--- a/e-relationalFromSql/src/main/resources/build-info.properties
+++ b/e-relationalFromSql/src/main/resources/build-info.properties
@@ -1,0 +1,3 @@
+# Contains informations aboud DPU build. This file is used by
+# cz.cuni.mff.xrg.uv.boost.dpu.vaadin.AboutTab. Do not modify it's content!
+build.timestamp = ${build.timestamp}

--- a/e-relationalFromSql/src/test/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlTest.java
+++ b/e-relationalFromSql/src/test/java/eu/unifiedviews/plugins/extractor/relationalfromsql/RelationalFromSqlTest.java
@@ -20,7 +20,8 @@ import org.junit.Test;
 import cz.cuni.mff.xrg.odcs.dpu.test.TestEnvironment;
 import eu.unifiedviews.dataunit.relational.RelationalDataUnit;
 import eu.unifiedviews.dataunit.relational.WritableRelationalDataUnit;
-import eu.unifiedviews.helpers.dataunit.relationalhelper.RelationalHelper;
+import eu.unifiedviews.helpers.dataunit.relational.RelationalHelper;
+import eu.unifiedviews.helpers.dpu.test.config.ConfigurationBuilder;
 import eu.unifiedviews.plugins.extractor.relationalfromsql.SqlDatabase.DatabaseType;
 
 public class RelationalFromSqlTest {
@@ -78,7 +79,7 @@ public class RelationalFromSqlTest {
     @Test
     public void selectSingleTableCheckTargetTableTest() throws Exception {
         RelationalFromSqlConfig_V2 config = createConfig(SELECT_ONE_TABLE_QUERY);
-        this.dpu.configureDirectly(config);
+        this.dpu.configure((new ConfigurationBuilder()).setDpuConfiguration(config).toString());
         Connection sourceConnection = null;
         Connection dataUnitConnection = null;
         try {
@@ -106,7 +107,7 @@ public class RelationalFromSqlTest {
     @Test
     public void selectSingleTableCheckTargetTableContent() throws Exception {
         RelationalFromSqlConfig_V2 config = createConfig(SELECT_ONE_TABLE_QUERY);
-        this.dpu.configureDirectly(config);
+        this.dpu.configure((new ConfigurationBuilder()).setDpuConfiguration(config).toString());
         Connection sourceConnection = null;
         Connection dataUnitConnection = null;
         ResultSet rs = null;
@@ -149,7 +150,7 @@ public class RelationalFromSqlTest {
     @Test
     public void selectJoinTablesCheckTargetTableTest() throws Exception {
         RelationalFromSqlConfig_V2 config = createConfig(SELECT_JOIN_TABLES_QUERY);
-        this.dpu.configureDirectly(config);
+        this.dpu.configure((new ConfigurationBuilder()).setDpuConfiguration(config).toString());
         Connection sourceConnection = null;
         Connection dataUnitConnection = null;
         try {
@@ -178,7 +179,7 @@ public class RelationalFromSqlTest {
     @Test
     public void selectJoinTablesCheckTargetTableContent() throws Exception {
         RelationalFromSqlConfig_V2 config = createConfig(SELECT_JOIN_TABLES_QUERY);
-        this.dpu.configureDirectly(config);
+        this.dpu.configure((new ConfigurationBuilder()).setDpuConfiguration(config).toString());
         Connection sourceConnection = null;
         Connection dataUnitConnection = null;
         ResultSet rs = null;


### PR DESCRIPTION
Migration of DPU to helpers 2.0.0 DPU functionality has not been tested as it's not known to me.

I can't even build this DPU for error (develop branch):
```
Failed to execute goal on project uv-e-relationalFromSql: Could not resolve dependencies for project eu.unifiedviews.plugins:uv-e-relationalFromSql:bundle:1.0.0-SNAPSHOT: Failure to find com.oracle:ojdbc7:jar:12.1.0.2.0 in http://maven.eea.sk/artifactory/public/ was cached in the local repository, resolution will not be reattempted until the update interval of maven.eea.sk has elapsed or updates are forced -> [Help 1]
```

Note: You may consider localization of about.html.