### PR TITLE
t-Tabular: Initial column bug fix

### DIFF
--- a/t-tabular/README.md
+++ b/t-tabular/README.md
@@ -35,7 +35,7 @@
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
-|2.0.2 | Fixed bug with wrong initial column. |
+|2.0.2 | Fixed bug with wrong initial column. First column wrongly named as "col2" instead of "col1". |
 |2.0.1 | fixes in build dependencies |
 |2.0.0            |Replaced with the DPU taken from the repository https://github.com/mff-uk/DPUs.|
 |1.5.0            |N/A                         |

--- a/t-tabular/README.md
+++ b/t-tabular/README.md
@@ -35,6 +35,7 @@
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
+|2.0.2 | Fixed bug with wrong initial column. |
 |2.0.1 | fixes in build dependencies |
 |2.0.0            |Replaced with the DPU taken from the repository https://github.com/mff-uk/DPUs.|
 |1.5.0            |N/A                         |

--- a/t-tabular/pom.xml
+++ b/t-tabular/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-tabular</artifactId>
 	<name>T-Tabular</name>
 	<description>Convert tabular data into rdf data.</description>
-	<version>2.0.1</version>
+	<version>2.0.2-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXls.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXls.java
@@ -4,7 +4,6 @@ import cz.cuni.mff.xrg.uv.transformer.tabular.column.ColumnType;
 import cz.cuni.mff.xrg.uv.transformer.tabular.column.NamedCell_V1;
 import cz.cuni.mff.xrg.uv.transformer.tabular.mapper.TableToRdf;
 import cz.cuni.mff.xrg.uv.transformer.tabular.mapper.TableToRdfConfigurator;
-import eu.unifiedviews.dpu.DPUContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -177,7 +176,8 @@ public class ParserXls implements Parser {
             if (row == null) {
                 continue;
             }
-            final int columnStart = row.getFirstCellNum();
+            // We use zero as the first column must be column 1.
+            final int columnStart = 0;
             final int columnEnd = row.getLastCellNum();
             // generate header
             if (!headerGenerated) {
@@ -195,12 +195,10 @@ public class ParserXls implements Parser {
                 }
                 if (columnNames == null) {
                     columnNames = new ArrayList<>(columnEnd);
-                    // Generate column names, columns may not start from 0, so we use special
-                    // variable to count from 0.
+                    // Generate column names, first column is col1.
                     int columnIndex = 0;
                     for (int i = columnStart; i < columnEnd; i++) {
-                        ++columnIndex;
-                        columnNames.add("col" + Integer.toString(columnIndex + 1));
+                        columnNames.add("col" + Integer.toString(++columnIndex));
                     }
                 }
                 // add user defined names


### PR DESCRIPTION
T-Tabular wrongly named columns in xls file. This lead to a strange behaviour with automatically generated column names: col1, col2, ...
It looks like the first column has been labelled as col2 instead of col1.

This pull request should fix this behaviour, ie. first column is now denoted as col1.
