### PR TITLE
Dpu/t sparql update 2.0.4

### DIFF
--- a/t-sparqlUpdate/README.md
+++ b/t-sparqlUpdate/README.md
@@ -37,7 +37,8 @@
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
-|2.0.3-SNAPSHOT            | sk localization |
+|2.0.4            | Adde error message in case of SPARQL update query failure. |
+|2.0.3            | sk localization |
 |2.0.2            | TODO to describe changes in commit 909c28ebb1a35c235981027285daa3c9bdd2eda4|
 |2.0.1            | fixes in build dependencies |
 |2.0.0            | Imported from the repository https://github.com/mff-uk/DPUs, using helpers 2.0.0 |

--- a/t-sparqlUpdate/pom.xml
+++ b/t-sparqlUpdate/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-sparqlUpdate</artifactId>
 	<name>T-SparqlUpdate</name>
 	<description>Execute a single SPARQL update query. Does not support quads!</description>
-	<version>2.0.3-SNAPSHOT</version>
+	<version>2.0.4-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-sparqlUpdate/src/main/java/cz/cuni/mff/xrg/uv/transformer/sparql/update/SparqlUpdate.java
+++ b/t-sparqlUpdate/src/main/java/cz/cuni/mff/xrg/uv/transformer/sparql/update/SparqlUpdate.java
@@ -212,9 +212,9 @@ public class SparqlUpdate extends AbstractDpu<SparqlUpdateConfig_V1> {
             }
             update.execute();
         } catch (MalformedQueryException | UpdateExecutionException ex) {
-            throw ContextUtils.dpuException(ctx, "sparqlUpdate.dpu.error.query", ex);
+            throw ContextUtils.dpuException(ctx, ex, "sparqlUpdate.dpu.error.query");
         } catch (RepositoryException ex) {
-            throw ContextUtils.dpuException(ctx, "sparqlUpdate.dpu.error.repository", ex);
+            throw ContextUtils.dpuException(ctx, ex, "sparqlUpdate.dpu.error.repository");
         }
     }
 
@@ -230,7 +230,7 @@ public class SparqlUpdate extends AbstractDpu<SparqlUpdateConfig_V1> {
         try {
             return rdfOutput.addNewDataGraph(symbolicName);
         } catch (DataUnitException ex) {
-            throw ContextUtils.dpuException(ctx, "sparqlUpdate.dpu.error.cantAddGraph", ex);
+            throw ContextUtils.dpuException(ctx, ex, "sparqlUpdate.dpu.error.cantAddGraph");
         }
     }
 
@@ -245,7 +245,7 @@ public class SparqlUpdate extends AbstractDpu<SparqlUpdateConfig_V1> {
         try {
             return rdfOutput.addNewDataGraph(entry.getSymbolicName() + suffix);
         } catch (DataUnitException ex) {
-            throw ContextUtils.dpuException(ctx, "sparqlUpdate.dpu.error.cantAddGraph", ex);
+            throw ContextUtils.dpuException(ctx, ex, "sparqlUpdate.dpu.error.cantAddGraph");
         }
     }
 
@@ -280,7 +280,7 @@ public class SparqlUpdate extends AbstractDpu<SparqlUpdateConfig_V1> {
                     try {
                         result.add(entry.getDataGraphURI());
                     } catch (DataUnitException ex) {
-                        throw ContextUtils.dpuException(ctx, "sparqlUpdate.dpu.error.dataUnit", ex);
+                        throw ContextUtils.dpuException(ctx, ex, "sparqlUpdate.dpu.error.dataUnit");
                     }
                 }
             }


### PR DESCRIPTION
SparqlUpdate was missing error report in case of problems related to sparql query execution (#206).

Now the original exception is appended after the "Problem with query" exception. Example of event:
```
Pipeline execution:4649Time:May 4, 2015 2:28:55 PMType:PIPELINE_ERRORShort message:Pipeline execution failed.Message:
Execution failed because: Operation failed.eu.unifiedviews.dpu.DPUException: Operation failed.
at eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultTolerance.checkFailState(FaultTolerance.java:243)
at eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultTolerance.execute(FaultTolerance.java:301)
at cz.cuni.mff.xrg.uv.transformer.sparql.update.SparqlUpdate.updateEntries(SparqlUpdate.java:169)
at cz.cuni.mff.xrg.uv.transformer.sparql.update.SparqlUpdate.innerExecute(SparqlUpdate.java:111)
at eu.unifiedviews.helpers.dpu.exec.AbstractDpu.execute(AbstractDpu.java:117)
at cz.cuni.mff.xrg.odcs.backend.execution.dpu.DPUExecutor.executeInstance(DPUExecutor.java:232)
at cz.cuni.mff.xrg.odcs.backend.execution.dpu.DPUExecutor.execute(DPUExecutor.java:370)
at cz.cuni.mff.xrg.odcs.backend.execution.dpu.DPUExecutor.run(DPUExecutor.java:452)
at java.lang.Thread.run(Thread.java:745)
Caused by: eu.unifiedviews.dpu.DPUException: Problem with query.
at eu.unifiedviews.helpers.dpu.context.ContextUtils.dpuException(ContextUtils.java:193)
at cz.cuni.mff.xrg.uv.transformer.sparql.update.SparqlUpdate.executeUpdateQuery(SparqlUpdate.java:215)
at cz.cuni.mff.xrg.uv.transformer.sparql.update.SparqlUpdate$5.action(SparqlUpdate.java:174)
at eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultTolerance.execute(FaultTolerance.java:298)
... 7 more
Caused by: org.openrdf.query.MalformedQueryException: Lexical error at line 1, column 28. Encountered: " " (32), after : "s"
at org.openrdf.query.parser.sparql.SPARQLParser.parseUpdate(SPARQLParser.java:141)
at org.openrdf.query.parser.QueryParserUtil.parseUpdate(QueryParserUtil.java:112)
at org.openrdf.repository.sail.SailRepositoryConnection.prepareUpdate(SailRepositoryConnection.java:215)
at org.openrdf.repository.base.RepositoryConnectionBase.prepareUpdate(RepositoryConnectionBase.java:180)
at cz.cuni.mff.xrg.uv.transformer.sparql.update.SparqlUpdate.executeUpdateQuery(SparqlUpdate.java:203)
... 9 more
Caused by: org.openrdf.query.parser.sparql.ast.TokenMgrError: Lexical error at line 1, column 28. Encountered: " " (32), after : "s"
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilderTokenManager.getNextToken(SyntaxTreeBuilderTokenManager.java:3499)
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder.jj_ntk(SyntaxTreeBuilder.java:8774)
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder.GroupGraphPattern(SyntaxTreeBuilder.java:1839)
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder.Modify(SyntaxTreeBuilder.java:8017)
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder.Update(SyntaxTreeBuilder.java:7491)
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder.UpdateContainer(SyntaxTreeBuilder.java:150)
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder.UpdateSequence(SyntaxTreeBuilder.java:96)
at org.openrdf.query.parser.sparql.ast.SyntaxTreeBuilder.parseUpdateSequence(SyntaxTreeBuilder.java:48)
at org.openrdf.query.parser.sparql.SPARQLParser.parseUpdate(SPARQLParser.java:68)
... 13 more
```