### PR TITLE
T-Tabular to properly handle empty strings

### DIFF
--- a/t-tabular/README.md
+++ b/t-tabular/README.md
@@ -35,6 +35,7 @@
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
+|2.1.1 | Fixed bug with :Skip n first lines: for XLS, where empty text box makes configuration invalid. |
 |2.1.0 | Added option "Generate labels". |
 |2.0.2 | Fixed bug with wrong initial column. First column wrongly named as "col2" instead of "col1". |
 |2.0.1 | fixes in build dependencies |

--- a/t-tabular/pom.xml
+++ b/t-tabular/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-tabular</artifactId>
 	<name>T-Tabular</name>
 	<description>Convert tabular data into rdf data.</description>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularVaadinDialog.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularVaadinDialog.java
@@ -609,7 +609,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
             checkXlsHasHeader.setValue(c.isHasHeader());
         } else {
             txtXlsSheetName.setValue("");
-            txtXlsLinesToIgnore.setValue("");
+            txtXlsLinesToIgnore.setValue("0");
             loadCellMapping(Collections.EMPTY_LIST);
             checkXlsHasHeader.setValue(true);
         }
@@ -670,7 +670,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
             cnf.setDelimiterChar(txtCsvDelimeterChar.getValue());
             try {
                 final String linesToSkipStr = txtCsvLinesToIgnore.getValue();
-                if (linesToSkipStr == null) {
+                if (linesToSkipStr == null || linesToSkipStr.isEmpty()) {
                     cnf.setLinesToIgnore(0);
                 } else {
                     cnf.setLinesToIgnore(
@@ -689,7 +689,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
 
             try {
                 final String linesToSkipStr = txtXlsLinesToIgnore.getValue();
-                if (linesToSkipStr == null) {
+                if (linesToSkipStr == null || linesToSkipStr.isEmpty()) {
                     cnf.setLinesToIgnore(0);
                 } else {
                     cnf.setLinesToIgnore(Integer.parseInt(linesToSkipStr));


### PR DESCRIPTION
Tabular used empty string as a default values for xls.linesToSkip. At the same time in case of xls mode active, this xls.linesToSkip was checked for null (no lines to skip) or converted into a number. 

This cause the problem as empty string is not null and also not a number. 

As a fix, empty string is now consider to be equal to "0" = "skip no lines". Also "0" is used as a default values. 

Motivated by #223