### PR TITLE
t-tabular strip null values and limit size of row

### DIFF
--- a/t-tabular/README.md
+++ b/t-tabular/README.md
@@ -35,12 +35,12 @@
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
-|2.2.0 | Added possibility to strip null value in header. For XSL: If row is shorter than header then row is expanded. |
-|2.1.0            | Update to API 2.1.0.Combobox for Encoding in Dialog |
-|                 | Fixed bug with :Skip n first lines: for XLS, where empty text box makes configuration invalid. |
+|2.1.0            | For XLS files: Added possibility to strip null value in header. If row is shorter than header then row is expanded. |
+|                 | Updated to API 2.1.0. Combobox for selection of various encodings in DPU's dialog |
+|                 | Fixed bug with :Skip n first lines: for XLS files, where empty text box makes configuration invalid. |
 |                 | Added option "Generate labels". |
 |                 | Fixed bug with wrong initial column. First column wrongly named as "col2" instead of "col1". |
-|2.0.1 | fixes in build dependencies |
+|2.0.1            | fixes in build dependencies |
 |2.0.0            |Replaced with the DPU taken from the repository https://github.com/mff-uk/DPUs.|
 |1.5.0            |N/A                         |
 |1.4.0            |N/A                         |

--- a/t-tabular/README.md
+++ b/t-tabular/README.md
@@ -35,7 +35,8 @@
 
 |Version          |Release notes               |
 |-----------------|----------------------------|
-|2.1.0            | Update to API 2.1.0.Combobox for Encoding in Dialog |        
+|2.2.0 | Added possibility to strip null value in header. For XSL: If row is shorter than header then row is expanded. |
+|2.1.0            | Update to API 2.1.0.Combobox for Encoding in Dialog |
 |                 | Fixed bug with :Skip n first lines: for XLS, where empty text box makes configuration invalid. |
 |                 | Added option "Generate labels". |
 |                 | Fixed bug with wrong initial column. First column wrongly named as "col2" instead of "col1". |

--- a/t-tabular/pom.xml
+++ b/t-tabular/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-tabular</artifactId>
 	<name>T-Tabular</name>
 	<description>Convert tabular data into rdf data.</description>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-tabular/pom.xml
+++ b/t-tabular/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-tabular</artifactId>
 	<name>T-Tabular</name>
 	<description>Convert tabular data into rdf data.</description>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularConfig_V2.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularConfig_V2.java
@@ -123,7 +123,7 @@ public class TabularConfig_V2 {
     private String xlsSheetName = null;
 
     /**
-     * If checked same row counter is used for all files. 
+     * If checked same row counter is used for all files. Used only for xsls.
      */
     private boolean staticRowCounter = false;
 
@@ -148,6 +148,11 @@ public class TabularConfig_V2 {
      * Generate RDF.LABEL for columns from colum name.
      */
     private boolean generateLabels = false;
+
+    /**
+     * If set then trailing null values in header are ignored.
+     */
+    private boolean stripHeader = false;
 
     public TabularConfig_V2() {
     }
@@ -336,6 +341,14 @@ public class TabularConfig_V2 {
         this.generateLabels = generateLabels;
     }
 
+    public boolean isStripHeader() {
+        return stripHeader;
+    }
+
+    public void setStripHeader(boolean stripHeader) {
+        this.stripHeader = stripHeader;
+    }
+
     public TableToRdfConfig getTableToRdfConfig() {
         return new TableToRdfConfig(keyColumn, baseURI, columnsInfo,
                 generateNew, rowsClass, ignoreBlankCells, columnsInfoAdv,
@@ -359,7 +372,7 @@ public class TabularConfig_V2 {
         return new ParserXlsConfig(xlsSheetName, linesToIgnore, hasHeader,
                 namedCells, 
                 rowsLimit == null || rowsLimit == -1 ? null : rowsLimit,
-                staticRowCounter);
+                staticRowCounter, stripHeader);
     }
 
 }

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularVaadinDialog.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularVaadinDialog.java
@@ -74,6 +74,8 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
 
     private CheckBox checkXlsHasHeader;
 
+    private CheckBox checkXlsStripHeader;
+
     /**
      * Layout for basic column mapping.
      */
@@ -276,6 +278,12 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
         this.checkXlsHasHeader.setDescription("Uncheck if there is no header in given file. "
                 + "The columns are then accessible under names col0, col1, ..");
         xlsLayout.addComponent(this.checkXlsHasHeader);
+
+        this.checkXlsStripHeader = new CheckBox("Strip header for nulls");
+        this.checkXlsStripHeader.setDescription("If set then trailing null values in header are removed."
+                + "This can be usefull if header is bigger then data, ie. 'Diff number of cells in header' "
+                + "exception is thrown.");
+        xlsLayout.addComponent(this.checkXlsStripHeader);
 
         // add change listener
         this.optionTableType.addValueChangeListener(new Property.ValueChangeListener() {
@@ -485,6 +493,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
         txtXlsSheetName.setEnabled(xlsEnabled);
         txtXlsLinesToIgnore.setEnabled(xlsEnabled);
         checkXlsHasHeader.setEnabled(xlsEnabled);
+        checkXlsStripHeader.setEnabled(xlsEnabled);
         for (PropertyNamedCell namedCell : xlsNamedCells) {
             namedCell.setEnabled(xlsEnabled);
         }
@@ -616,11 +625,13 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
             txtXlsLinesToIgnore.setValue(c.getLinesToIgnore().toString());
             loadCellMapping(c.getNamedCells());
             checkXlsHasHeader.setValue(c.isHasHeader());
+            checkXlsStripHeader.setValue(c.isStripHeader());
         } else {
             txtXlsSheetName.setValue("");
             txtXlsLinesToIgnore.setValue("0");
             loadCellMapping(Collections.EMPTY_LIST);
             checkXlsHasHeader.setValue(true);
+            checkXlsStripHeader.setValue(false);
         }
         //
         // other data
@@ -712,6 +723,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
             storeCellMapping(cnf.getNamedCells());
 
             cnf.setHasHeader(checkXlsHasHeader.getValue());
+            cnf.setStripHeader(checkXlsStripHeader.getValue());
         }
         //
         // other data

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/mapper/TableToRdfConfigurator.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/mapper/TableToRdfConfigurator.java
@@ -74,7 +74,13 @@ public class TableToRdfConfigurator {
             //
             final String columnName;
             if (header != null) {
-                columnName = header.get(index);
+                if (header.get(index) != null) {
+                    columnName = header.get(index);
+                } else {
+                    LOG.info("Generated value used for column with 'null' name.");
+                    // use generated one - first is col1, col2 ...
+                    columnName = "col" + Integer.toString(index + 1);
+                }
             } else {
                 // use generated one - first is col1, col2 ... 
                 columnName = "col" + Integer.toString(index + 1);

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXlsConfig.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXlsConfig.java
@@ -26,9 +26,12 @@ public class ParserXlsConfig {
 
     final boolean checkStaticRowCounter;
 
+    final boolean stripHeader;
+
     public ParserXlsConfig(String sheetName, int numberOfStartLinesToIgnore,
             boolean hasHeader, List<NamedCell_V1> namedCells,
-            Integer rowLimit, boolean checkStaticRowCounter) {
+            Integer rowLimit, boolean checkStaticRowCounter,
+            boolean stripHeader) {
         this.sheetName = sheetName;
         this.numberOfStartLinesToIgnore = numberOfStartLinesToIgnore;
         this.hasHeader = hasHeader;
@@ -39,6 +42,7 @@ public class ParserXlsConfig {
         }
         this.rowLimit = rowLimit;
         this.checkStaticRowCounter = checkStaticRowCounter;
+        this.stripHeader = stripHeader;
     }
     
 }


### PR DESCRIPTION
There is an issue for xls-like files exportet from google docs, where the rows (and particularly header) is extended by null values.In combination with full column mapping this would cause generation of meaningless and empty records. 

In order to solve that we added possibility to strip the null values from header line - only for xls-like files.

Another very important feature is limiting the row size, as if the row is longer then the header then is would cause corruption of named data.

Although the changes should not affect existing configuration and use-cases, approach with caution.