### PR TITLE
Unit testing dependencies reused from uv-pom-dpu

### DIFF
--- a/e-distributionMetadata/pom.xml
+++ b/e-distributionMetadata/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -13,7 +13,7 @@
 	<artifactId>uv-e-distributionMetadata</artifactId>
 	<name>E-DistributionMetadata</name>
 	<description>Enables designers to input distribution level metadata</description>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/e-filesDownload/pom.xml
+++ b/e-filesDownload/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-e-filesDownload</artifactId>
 	<name>E-FilesDownload</name>
 	<description>Downloads list of files. Replaces E-FilesFromLocal and E-HttpDownload.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -113,12 +113,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<!-- Core UnifiedViews testing support. -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/e-filesDownload/pom.xml
+++ b/e-filesDownload/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -113,12 +113,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<!-- UNIT Test dependencies. -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<!-- Core UnifiedViews testing support. -->
 		<dependency>

--- a/e-relationalFromSql/pom.xml
+++ b/e-relationalFromSql/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>uv-e-relationalFromSql</artifactId>
 	<name>E-RelationalFromSql</name>
 	<description>Extracts data from relational database using SQL queries and stores them into internal data unit relational database</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -143,11 +143,7 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- JUnit tests dependencies -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
+		<!-- Unit tests dependencies -->
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/e-relationalFromSql/pom.xml
+++ b/e-relationalFromSql/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -123,7 +123,6 @@
 		</dependency>
 
 		<!-- UnifiedViews helpers. -->
-
 		<dependency>
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dataunit-helpers</artifactId>
@@ -134,13 +133,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-
-		<!-- Core UnifiedViews testing support. -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 
 		<!-- Unit tests dependencies -->

--- a/l-filesToParliament/pom.xml
+++ b/l-filesToParliament/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-l-filesToParliament</artifactId>
 	<name>L-FilesToParliament</name>
 	<description>Uploads files to Parliament.</description>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -54,11 +54,6 @@
 			<artifactId>httpcore-osgi</artifactId>
 			<version>4.3.2</version>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/l-filesToParliament/pom.xml
+++ b/l-filesToParliament/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 

--- a/l-filesToVirtuoso/pom.xml
+++ b/l-filesToVirtuoso/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-l-filesToVirtuoso</artifactId>
 	<name>L-FilesToVirtuoso</name>
 	<description>VirtuosoLoader issues Virtuoso internal functions to load directory of RDF data.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/l-filesUpload/pom.xml
+++ b/l-filesUpload/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-l-filesUpload</artifactId>
 	<name>L-FilesUpload</name>
 	<description>Uploads list of files. Replaces L-FilesToLocalFS and L-FilesToScp.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -113,12 +113,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<!-- UNIT Test dependencies. -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<!-- Core UnifiedViews testing support. -->
 		<dependency>

--- a/l-filesUpload/pom.xml
+++ b/l-filesUpload/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -113,12 +113,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<!-- Core UnifiedViews testing support. -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/l-rdfToVirtuoso/pom.xml
+++ b/l-rdfToVirtuoso/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -14,7 +14,7 @@
 	<artifactId>uv-l-rdfToVirtuoso</artifactId>
 	<name>L-RdfToVirtuoso</name>
 	<description>Loads RDF data to Virtuoso using OpenRDF Repository API (VirtuosoRepository).</description>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/l-relationalToSql/pom.xml
+++ b/l-relationalToSql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -40,12 +40,6 @@
 			<scope>compile</scope>
 		</dependency>
 
-		<!-- Unit tests dependencies -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/l-relationalToSql/pom.xml
+++ b/l-relationalToSql/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-l-relationalToSql</artifactId>
 	<name>L-RelationalToSql</name>
 	<description>Loads data from internal data unit relational database into external SQL database</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -40,13 +40,7 @@
 			<scope>compile</scope>
 		</dependency>
 
-		<!-- JUnit tests dependencies -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
+		<!-- Unit tests dependencies -->
 		<dependency>
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>module-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>eu.unifiedviews.plugins</groupId>
     <artifactId>uv-plugin-dpus</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Maven aggregation project for general purpose DPU implementations.</description>
 

--- a/t-filesFilter/pom.xml
+++ b/t-filesFilter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -13,7 +13,7 @@
 	<artifactId>uv-t-filesFilter</artifactId>
 	<description>Filter files.</description>
 	<packaging>bundle</packaging>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<name>T-FilesFilter</name>
 
 	<properties>

--- a/t-filesFindAndReplace/pom.xml
+++ b/t-filesFindAndReplace/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -14,7 +14,7 @@
 	<artifactId>uv-t-filesFindAndReplace</artifactId>
 	<name>T-FilesFindAndReplace</name>
 	<description>Finds and replace string in files.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-filesMerger/pom.xml
+++ b/t-filesMerger/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-filesMerger</artifactId>
 	<name>T-FilesMerger</name>
 	<description></description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-filesRenamer/pom.xml
+++ b/t-filesRenamer/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-filesRenamer</artifactId>
 	<name>T-FilesRenamer</name>
 	<description>Rename files</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-filesRenamer/pom.xml
+++ b/t-filesRenamer/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -37,12 +37,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<!-- UNIT Test dependencies -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/t-filesToRdf/pom.xml
+++ b/t-filesToRdf/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-filesToRdf</artifactId>
 	<name>T-FilesToRdf</name>
 	<description>Extracts RDF data from Files (any file format) and adds them to RDF.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-filterValidXml/pom.xml
+++ b/t-filterValidXml/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -37,11 +37,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/t-filterValidXml/pom.xml
+++ b/t-filterValidXml/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>uv-t-filterValidXml</artifactId>
 	<description>Validates XML inputs in 3 ways: checks if the XML is well formed, checks if it conforms to a specified XSD scheme and validates using specified XSLT template</description>
 	<packaging>bundle</packaging>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<name> T-FilterValidXml</name>
 
 	<properties>
@@ -41,11 +41,6 @@
 		<dependency>
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/t-gunzipper/pom.xml
+++ b/t-gunzipper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -40,12 +40,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-		</dependency>
-		<!-- Core UnifiedViews testing support. -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/t-gunzipper/pom.xml
+++ b/t-gunzipper/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-gunzipper</artifactId>
 	<name>T-Gunzipper</name>
 	<description>Plugin unzipping GZIP archives</description>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -40,12 +40,6 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-		</dependency>
-		<!-- UNIT Test dependencies. -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<!-- Core UnifiedViews testing support. -->
 		<dependency>

--- a/t-gzipper/pom.xml
+++ b/t-gzipper/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -42,12 +42,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<scope>provided</scope>
-		</dependency>
-		<!-- Core UnifiedViews testing support. -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/t-gzipper/pom.xml
+++ b/t-gzipper/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>uv-t-gzipper</artifactId>
 	<description>Transform any file to archive using GZIP compression.</description>
 	<packaging>bundle</packaging>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<name>T-Gzipper</name>
 
 	<properties>
@@ -42,12 +42,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<scope>provided</scope>
-		</dependency>
-		<!-- UNIT Test dependencies. -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<!-- Core UnifiedViews testing support. -->
 		<dependency>

--- a/t-metadata/pom.xml
+++ b/t-metadata/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-metadata</artifactId>
 	<name>T-Metadata</name>
 	<description>Generates metadata on output from input</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-rdfMerger/pom.xml
+++ b/t-rdfMerger/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-rdfMerger</artifactId>
 	<name>T-RdfMerger</name>
 	<description></description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-rdfToFiles/pom.xml
+++ b/t-rdfToFiles/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-rdfToFiles</artifactId>
 	<name>T-RdfToFiles</name>
 	<description>Transform RDF graphs into files.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-rdfValidator/pom.xml
+++ b/t-rdfValidator/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -58,11 +58,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/t-rdfValidator/pom.xml
+++ b/t-rdfValidator/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>uv-t-rdfValidator</artifactId>
 	<name>T-RdfValidator</name>
 	<description>Validates RDF data.</description>
-	<version>2.0.0</version>
+	<version>2.0.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -58,11 +58,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>eu.unifiedviews</groupId>

--- a/t-relational/pom.xml
+++ b/t-relational/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -35,11 +35,6 @@
 		</dependency>
 
 		<!-- Unit tests dependencies -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/t-relational/pom.xml
+++ b/t-relational/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-relational</artifactId>
 	<name>T-Relational</name>
 	<description>Transforms input database tables using SQL into one output table</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -34,19 +34,12 @@
 			<scope>compile</scope>
 		</dependency>
 
-		<!-- JUnit tests dependencies -->
+		<!-- Unit tests dependencies -->
 		<dependency>
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>module-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/t-sparqlConstruct/pom.xml
+++ b/t-sparqlConstruct/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -13,7 +13,7 @@
 	<artifactId>uv-t-sparqlConstruct</artifactId>
 	<name>T-SparqlConstruct</name>
 	<description>Execute a single SPARQL construct query. Does not support quads!</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-sparqlSelect/pom.xml
+++ b/t-sparqlSelect/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -13,7 +13,7 @@
 	<artifactId>uv-t-sparqlSelect</artifactId>
 	<name>T-SparqlSelect</name>
 	<description>SPARQL select transformer ~ RDF to csv. Does not validate query!</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-sparqlUpdate/pom.xml
+++ b/t-sparqlUpdate/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-sparqlUpdate</artifactId>
 	<name>T-SparqlUpdate</name>
 	<description>Execute a single SPARQL update query. Does not support quads!</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-tabular/pom.xml
+++ b/t-tabular/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-tabular</artifactId>
 	<name>T-Tabular</name>
 	<description>Convert tabular data into rdf data.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-tabularToRelational/pom.xml
+++ b/t-tabularToRelational/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 
@@ -39,12 +39,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<!-- UNIT Test dependencies -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/t-tabularToRelational/pom.xml
+++ b/t-tabularToRelational/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>uv-t-tabularToRelational</artifactId>
 	<name>T-TabularToRelational</name>
 	<description>Parse tabular file to relational data unit.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -44,11 +44,6 @@
 		<dependency>
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/t-unzipper/pom.xml
+++ b/t-unzipper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -48,11 +48,6 @@
 			<version>1.2.3</version>
 		</dependency>
 		<!-- UNIT Test dependencies -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/t-unzipper/pom.xml
+++ b/t-unzipper/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-unzipper</artifactId>
 	<name>T-UnZipper</name>
 	<description>UnZip input file into files based on zip content.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -51,11 +51,6 @@
 		<dependency>
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/t-xslt/pom.xml
+++ b/t-xslt/pom.xml
@@ -4,13 +4,13 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<groupId>eu.unifiedviews.plugins</groupId>
 	<artifactId>uv-t-xslt</artifactId>
-	<version>2.2.0</version>
+	<version>2.2.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 	<name>T-Xslt</name>
 	<description>Description of XSLT.</description>
@@ -45,12 +45,7 @@
 			<version>1.2</version>
 			<scope>compile</scope>
 		</dependency>
-		<!-- - - - -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+		<!-- Unit test dependencies -->
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>

--- a/t-zipper/pom.xml
+++ b/t-zipper/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-zipper</artifactId>
 	<name>T-Zipper</name>
 	<description>Zip input files into zip file of given name.</description>
-	<version>2.1.0</version>
+	<version>2.1.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>
@@ -48,11 +48,6 @@
 			<scope>test</scope>
 		</dependency>
 		<!-- UNIT Test dependencies -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/t-zipper/pom.xml
+++ b/t-zipper/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>eu.unifiedviews</groupId>
 		<artifactId>uv-pom-dpu</artifactId>
-		<version>2.1.0</version>
+		<version>2.1.1-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
@@ -40,12 +40,6 @@
 			<groupId>eu.unifiedviews</groupId>
 			<artifactId>uv-dpu-helpers</artifactId>
 			<scope>compile</scope>
-		</dependency>
-		<!-- Core UnifiedViews testing support. -->
-		<dependency>
-			<groupId>eu.unifiedviews</groupId>
-			<artifactId>module-test</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<!-- UNIT Test dependencies -->
 		<dependency>


### PR DESCRIPTION
Removed dependencies on junit and module-test from DPUs (pom.xml), dependecies defined in uv-pom-dpu.
See UnifiedViews/Plugin-DevEnv#56 - dependecy for this pull request.

Version of all DPUs raised on patch level, when feature finished, it must be merged properly.
