### PR TITLE
Dpu/t tabular 2.2.1

### DIFF
--- a/t-tabular/CHANGELOG.md
+++ b/t-tabular/CHANGELOG.md
@@ -1,6 +1,10 @@
 T-Tabular
 ----------
 
+v2.2.1
+---
+* Fixed bug with wrongly moved NamedCell_V1 class causing corruption of tabular configuration for xls files with named cells.
+
 v2.2.0
 ---
 * Fixed bug with missing trailing columns in xls-like files with empty leading columns and header autogeneration

--- a/t-tabular/pom.xml
+++ b/t-tabular/pom.xml
@@ -12,7 +12,7 @@
 	<artifactId>uv-t-tabular</artifactId>
 	<name>T-Tabular</name>
 	<description>Convert tabular data into rdf data.</description>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.1-SNAPSHOT</version>
 	<packaging>bundle</packaging>
 
 	<properties>

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularConfig_V2.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularConfig_V2.java
@@ -13,7 +13,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import eu.unifiedviews.plugins.transformer.tabular.column.NamedCell_V1;
+import cz.cuni.mff.xrg.uv.transformer.tabular.column.NamedCell_V1;
 
 /**
  *

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/column/NamedCell_V1.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/column/NamedCell_V1.java
@@ -1,4 +1,4 @@
-package eu.unifiedviews.plugins.transformer.tabular.column;
+package cz.cuni.mff.xrg.uv.transformer.tabular.column;
 
 /**
  * Used to specify cell in sheet for xls format.

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXls.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXls.java
@@ -23,7 +23,7 @@ import eu.unifiedviews.dpu.DPUException;
 import eu.unifiedviews.helpers.dpu.context.ContextUtils;
 import eu.unifiedviews.helpers.dpu.exec.UserExecContext;
 import eu.unifiedviews.plugins.transformer.tabular.column.ColumnType;
-import eu.unifiedviews.plugins.transformer.tabular.column.NamedCell_V1;
+import cz.cuni.mff.xrg.uv.transformer.tabular.column.NamedCell_V1;
 import eu.unifiedviews.plugins.transformer.tabular.parser.ParseFailed;
 import eu.unifiedviews.plugins.transformer.tabular.parser.Parser;
 

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXlsConfig.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserXlsConfig.java
@@ -3,7 +3,7 @@ package cz.cuni.mff.xrg.uv.transformer.tabular.parser;
 import java.util.Collections;
 import java.util.List;
 
-import eu.unifiedviews.plugins.transformer.tabular.column.NamedCell_V1;
+import cz.cuni.mff.xrg.uv.transformer.tabular.column.NamedCell_V1;
 
 /**
  * Configuration for {@link ParserXls}.

--- a/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/TabularVaadinDialog.java
+++ b/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/TabularVaadinDialog.java
@@ -23,7 +23,7 @@ import cz.cuni.mff.xrg.uv.transformer.tabular.parser.ParserType;
 import cz.cuni.mff.xrg.uv.transformer.tabular.parser.ParserXls;
 import eu.unifiedviews.dpu.config.DPUConfigException;
 import eu.unifiedviews.helpers.dpu.vaadin.dialog.AbstractDialog;
-import eu.unifiedviews.plugins.transformer.tabular.column.NamedCell_V1;
+import cz.cuni.mff.xrg.uv.transformer.tabular.column.NamedCell_V1;
 import eu.unifiedviews.plugins.transformer.tabular.gui.PropertyGroup;
 import eu.unifiedviews.plugins.transformer.tabular.gui.PropertyGroupAdv;
 import eu.unifiedviews.plugins.transformer.tabular.gui.PropertyNamedCell;

--- a/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/gui/PropertyNamedCell.java
+++ b/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/gui/PropertyNamedCell.java
@@ -4,7 +4,7 @@ import com.vaadin.ui.GridLayout;
 import com.vaadin.ui.TextField;
 
 import eu.unifiedviews.dpu.config.DPUConfigException;
-import eu.unifiedviews.plugins.transformer.tabular.column.NamedCell_V1;
+import cz.cuni.mff.xrg.uv.transformer.tabular.column.NamedCell_V1;
 
 /**
  * Component for {@link NamedCell_V1}.


### PR DESCRIPTION
Change of package for class NamedCell_V1 cause configuration for t-Tabular that uses xls and named cell to invalid.

This fix move the class back to original package and thus it's fixing old configuration - required by cuni instances.

Note: configurations with NamedCell_V1 in eu.unifiedviews package parsing xls a utilizing named cell are rendered invalid by this fix.
