### PR TITLE
Dpu/t tabular 2.2.1

### DIFF
--- a/t-tabular/CHANGELOG.md
+++ b/t-tabular/CHANGELOG.md
@@ -4,6 +4,7 @@ T-Tabular
 v2.2.1
 ---
 * Fixed bug with wrongly moved NamedCell_V1 class causing corruption of tabular configuration for xls files with named cells.
+* For DBF: Added possibility to trim trailing and leading spaces from values, dialog adjustments.
 
 v2.2.0
 ---

--- a/t-tabular/CHANGELOG.md
+++ b/t-tabular/CHANGELOG.md
@@ -3,7 +3,6 @@ T-Tabular
 
 v2.2.1
 ---
-* Fixed bug with wrongly moved NamedCell_V1 class causing corruption of tabular configuration for xls files with named cells.
 * For DBF: Added possibility to trim trailing and leading spaces from values, dialog adjustments.
 
 v2.2.0

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularConfig_V2.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/TabularConfig_V2.java
@@ -156,6 +156,11 @@ public class TabularConfig_V2 {
      */
     private boolean stripHeader = false;
 
+    /**
+     * If true then string values are trimmed before used.
+     */
+    private boolean dbfTrimString = false;
+
     public TabularConfig_V2() {
     }
 
@@ -351,6 +356,14 @@ public class TabularConfig_V2 {
         this.stripHeader = stripHeader;
     }
 
+    public boolean isDbfTrimString() {
+        return dbfTrimString;
+    }
+
+    public void setDbfTrimString(boolean dbfTrimString) {
+        this.dbfTrimString = dbfTrimString;
+    }
+
     public TableToRdfConfig getTableToRdfConfig() {
         return new TableToRdfConfig(keyColumn, baseURI, columnsInfo,
                 generateNew, rowsClass, ignoreBlankCells, columnsInfoAdv,
@@ -367,7 +380,7 @@ public class TabularConfig_V2 {
     public ParserDbfConfig getParserDbfConfig() {
         return new ParserDbfConfig(encoding,
                 rowsLimit == null || rowsLimit == -1 ? null : rowsLimit,
-                staticRowCounter);
+                staticRowCounter, dbfTrimString);
     }
 
     public ParserXlsConfig getParserXlsConfig() {

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserDbf.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserDbf.java
@@ -94,7 +94,12 @@ public class ParserDbf implements Parser {
             for (Object item : row) {
                 if (item instanceof byte[]) {
                     try {
-                        stringRow.add(new String((byte [])item, config.encoding));
+                        final String newString = new String((byte [])item, config.encoding);
+                        if (config.trimStringValues) {
+                            stringRow.add(newString.trim());
+                        } else {
+                            stringRow.add(newString);
+                        }
                     } catch (UnsupportedEncodingException ex) {
                         // terminate DPU as this can not be handled
                         throw new RuntimeException(ex);

--- a/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserDbfConfig.java
+++ b/t-tabular/src/main/java/cz/cuni/mff/xrg/uv/transformer/tabular/parser/ParserDbfConfig.java
@@ -12,11 +12,14 @@ public class ParserDbfConfig {
 
     final boolean checkStaticRowCounter;
 
+    final boolean trimStringValues;
+
     public ParserDbfConfig(String encoding, Integer rowLimit,
-            boolean checkStaticRowCounter) {
+            boolean checkStaticRowCounter, boolean trimStringValues) {
         this.encoding = encoding;
         this.rowLimit = rowLimit;
         this.checkStaticRowCounter = checkStaticRowCounter;
+        this.trimStringValues = trimStringValues;
     }
 
 }

--- a/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/TabularVaadinDialog.java
+++ b/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/TabularVaadinDialog.java
@@ -17,7 +17,6 @@ import com.vaadin.ui.TabSheet.Tab;
 import cz.cuni.mff.xrg.uv.transformer.tabular.Tabular;
 import cz.cuni.mff.xrg.uv.transformer.tabular.TabularConfig_V2;
 import cz.cuni.mff.xrg.uv.transformer.tabular.TabularOntology;
-import cz.cuni.mff.xrg.uv.transformer.tabular.TabularConfig_V2.AdvanceMapping;
 import cz.cuni.mff.xrg.uv.transformer.tabular.column.ColumnInfo_V1;
 import cz.cuni.mff.xrg.uv.transformer.tabular.parser.ParserType;
 import cz.cuni.mff.xrg.uv.transformer.tabular.parser.ParserXls;
@@ -79,6 +78,8 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
     private CheckBox checkXlsHasHeader;
 
     private CheckBox checkXlsStripHeader;
+
+    private CheckBox checkDbfTrimString;
 
     /**
      * Layout for basic column mapping.
@@ -302,6 +303,19 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
             }
         });
 
+        // DBF
+        final FormLayout dbfLayout = new FormLayout();
+        dbfLayout.setImmediate(true);
+        dbfLayout.setSpacing(true);
+        dbfLayout.setWidth("100%");
+        dbfLayout.setHeight("-1px");
+        dbfLayout.addComponent(new Label("DBF specific settings"));
+
+        this.checkDbfTrimString = new CheckBox("Remove trailing spaces");
+        this.checkDbfTrimString.setDescription("If checked then for every loaded string the leading and "
+                + "trailing spaces are removed before the value is futher processed.");
+        dbfLayout.addComponent(this.checkDbfTrimString);
+
         // --------------------- Mapping - simple ---------------------
         this.basicLayout = new GridLayout(5, 1);
         this.basicLayout.setWidth("100%");
@@ -384,6 +398,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
 
         configLayout.addComponent(generalLayout);
         configLayout.addComponent(csvLayout);
+        configLayout.addComponent(dbfLayout);
         configLayout.addComponent(xlsLayout);
 
         // main layout for whole dialog
@@ -490,6 +505,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
     private void setControllStates(ParserType value) {
         boolean csvEnabled = value == ParserType.CSV;
         boolean xlsEnabled = value == ParserType.XLS;
+        boolean dbfEnabled = value == ParserType.DBF;
 
         txtCsvQuoteChar.setEnabled(csvEnabled);
         txtCsvDelimeterChar.setEnabled(csvEnabled);
@@ -504,6 +520,8 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
         for (PropertyNamedCell namedCell : xlsNamedCells) {
             namedCell.setEnabled(xlsEnabled);
         }
+
+        checkDbfTrimString.setEnabled(dbfEnabled);
     }
 
     /**
@@ -640,6 +658,11 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
             checkXlsHasHeader.setValue(true);
             checkXlsStripHeader.setValue(false);
         }
+        if (c.getTableType() == ParserType.DBF) {
+            checkDbfTrimString.setValue(c.isDbfTrimString());
+        } else {
+            checkDbfTrimString.setValue(false);
+        }
         //
         // other data
         //
@@ -734,6 +757,8 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
 
             cnf.setHasHeader(checkXlsHasHeader.getValue());
             cnf.setStripHeader(checkXlsStripHeader.getValue());
+        } else if (value == ParserType.DBF) {
+            cnf.setDbfTrimString(checkDbfTrimString.getValue());
         }
         //
         // other data

--- a/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/TabularVaadinDialog.java
+++ b/t-tabular/src/main/java/eu/unifiedviews/plugins/transformer/tabular/TabularVaadinDialog.java
@@ -392,7 +392,7 @@ public class TabularVaadinDialog extends AbstractDialog<TabularConfig_V2> {
         // -------------------------------------------------------------
         // top layout with configuration
         final HorizontalLayout configLayout = new HorizontalLayout();
-        configLayout.setWidth("100%");
+        configLayout.setWidth("-1px");
         configLayout.setHeight("-1px");
         configLayout.setSpacing(true);
 


### PR DESCRIPTION
Some dbf files utilizes spaces to archive fixed size of cell content. An options for dbf file that enables removing of these spaces (leading, trailing) has been added.

It's new feature, but version is not raised as there was no release. 

