### PR TITLE
T-TabularToRelational DPU too robust - transforms any text into relational table; CSV validation possibility added

### DIFF
--- a/t-tabularToRelational/CHANGELOG.md
+++ b/t-tabularToRelational/CHANGELOG.md
@@ -1,6 +1,10 @@
 T-TabularToRelational
 ----------
 
+v2.2.3-SNAPSHOT
+---
+* added possibility to validate input CSV files
+
 v2.2.2
 ---
 * Update to helpers 2.1.3

--- a/t-tabularToRelational/doc/About.md
+++ b/t-tabularToRelational/doc/About.md
@@ -12,6 +12,7 @@ Parse tabular file to relational data unit.
 |**Charset** | Charset of input file |
 |**Quote character** | Field delimiter to use during parsing od CSV file. e.g. '"' |
 |**Sepatator** | Field separator to use during parsing of CSV file. e.g. ',' |
+|**Validate CSV files**|If checked, input CSV files are validated (row column counts are compared to user defined columns count) and DPU fails if CSV is not valid|
 |**Table of column mappings** | Name and types of culumns in CSV files. Also marks if column is used as primary key |
 
 ### Inputs and outputs

--- a/t-tabularToRelational/doc/About_sk.md
+++ b/t-tabularToRelational/doc/About_sk.md
@@ -11,7 +11,8 @@ Načíta súbor s tabuľovými dátami vo formáte CSV, XLS, XLSX alebo DBF a v�
 |**Dáta začínajú na riadku** | Definuje na ktorom riadku začínajú dáta |
 |**Znaková sada** | Znaková sada vstupného súboru |
 |**Znak úvodzoviek** | Znak na ohraničenie jednotlivých polí používaný pri parsovaní CSV súboru, napr. `"` |
-|**Oddelovač** | Oddelovač polí oužívaný pri parsovaní CSV súboru, napr. `,` |
+|**Oddelovač** | Oddelovač polí používaný pri parsovaní CSV súboru, napr. `,` |
+|**Validovať CSV súbory**|Ak zvolené, vstupné DPU súbory sú validované (počet stĺpcov v jednotlivých riadkoch sa porovnáva s počtom stĺpcov definovaných používateľom) a krok zlyhá ak je CSV nevalidné|
 |**Mapovacia tabuľka** | Uvedie sa definícia tabuľky, do ktorej sa majú uložiť tabuľkové dáta načítané zo súboru. Je potrebné uviesť želané názvy stĺpcov. Ich názvy nemusia byť zhodné s tými zo súboru. Stĺpce zo súboru sa premapujú do tabuľky automaticky podľa poradia (prvý stĺpec zo súboru na prvý stĺpec tabuľky, druhý na druhý atď). Dátový typ každého stĺpca je text (bez obmedzenia veľkosti). Voľba *Kompozitný kľúč?* znamená, že daný stĺpec sa stane súčasťou primárneho klúča vytváranej tabuľky. Vhodná voľba primárneho kľúču tabuľky môže urýchliť nasledovné spracovanie tabuľky v procese.
 
 ### Vstupy a výstupy

--- a/t-tabularToRelational/pom.xml
+++ b/t-tabularToRelational/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>uv-t-tabularToRelational</artifactId>
     <name>T-TabularToRelational</name>
     <description>Parse tabular file to relational data unit.</description>
-    <version>2.2.2</version>
+    <version>2.2.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <properties>
@@ -57,6 +57,11 @@
             <groupId>org.jamel.dbf</groupId>
             <artifactId>dbf-reader</artifactId>
             <version>0.1.0</version>
+        </dependency>
+        <dependency> <!-- Csv. -->
+            <groupId>net.sf.supercsv</groupId>
+            <artifactId>super-csv</artifactId>
+            <version>2.4.0</version>
         </dependency>
         <!-- UNIT Test dependencies -->
         <dependency>

--- a/t-tabularToRelational/src/main/java/eu/unifiedviews/plugins/transformer/tabulartorelational/TabularToRelationalConfig_V2.java
+++ b/t-tabularToRelational/src/main/java/eu/unifiedviews/plugins/transformer/tabulartorelational/TabularToRelationalConfig_V2.java
@@ -1,10 +1,10 @@
 package eu.unifiedviews.plugins.transformer.tabulartorelational;
 
-import eu.unifiedviews.plugins.transformer.tabulartorelational.model.ColumnMappingEntry;
-import eu.unifiedviews.plugins.transformer.tabulartorelational.model.ParserType;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import eu.unifiedviews.plugins.transformer.tabulartorelational.model.ColumnMappingEntry;
+import eu.unifiedviews.plugins.transformer.tabulartorelational.model.ParserType;
 
 /**
  * Class holds configuration of DPU.
@@ -25,6 +25,8 @@ public class TabularToRelationalConfig_V2 {
 
     private Integer dataBegginningRow;
 
+    private boolean processOnlyValidCsv;
+
     public TabularToRelationalConfig_V2() {
         // default values
         this.tableName = "";
@@ -34,6 +36,7 @@ public class TabularToRelationalConfig_V2 {
         this.columnMapping = new ArrayList<>();
         this.parserType = ParserType.CSV;
         this.dataBegginningRow = 1;
+        this.processOnlyValidCsv = false;
     }
 
     public String getTableName() {
@@ -92,7 +95,16 @@ public class TabularToRelationalConfig_V2 {
         this.dataBegginningRow = dataBegginningRow;
     }
 
-    @Override public String toString() {
+    public boolean isProcessOnlyValidCsv() {
+        return this.processOnlyValidCsv;
+    }
+
+    public void setProcessOnlyValidCsv(boolean processOnlyValidCsv) {
+        this.processOnlyValidCsv = processOnlyValidCsv;
+    }
+
+    @Override
+    public String toString() {
         return "TabularToRelationalConfig_V2{" +
                 "tableName='" + tableName + '\'' +
                 ", encoding='" + encoding + '\'' +

--- a/t-tabularToRelational/src/main/java/eu/unifiedviews/plugins/transformer/tabulartorelational/TabularToRelationalVaadinDialog.java
+++ b/t-tabularToRelational/src/main/java/eu/unifiedviews/plugins/transformer/tabulartorelational/TabularToRelationalVaadinDialog.java
@@ -33,6 +33,8 @@ public class TabularToRelationalVaadinDialog extends AbstractDialog<TabularToRel
 
     private Table table;
 
+    private CheckBox validCsvCheckbox;
+
     public TabularToRelationalVaadinDialog() {
         super(TabularToRelational.class);
     }
@@ -77,14 +79,14 @@ public class TabularToRelationalVaadinDialog extends AbstractDialog<TabularToRel
                 ParserType newParserType = (ParserType) e.getProperty().getValue();
                 switch (newParserType) {
                     case XLS:
-                        hideComponents(charsetSelect, fieldDelimiterField, fieldSeparatorField);
+                        hideComponents(charsetSelect, fieldDelimiterField, fieldSeparatorField, validCsvCheckbox);
                         break;
                     case CSV:
-                        showComponents(charsetSelect, fieldDelimiterField, fieldSeparatorField);
+                        showComponents(charsetSelect, fieldDelimiterField, fieldSeparatorField, validCsvCheckbox);
                         break;
                     case DBF:
                         showComponents(charsetSelect);
-                        hideComponents(fieldDelimiterField, fieldSeparatorField);
+                        hideComponents(fieldDelimiterField, fieldSeparatorField, validCsvCheckbox);
                         break;
                     default:
                 }
@@ -126,6 +128,10 @@ public class TabularToRelationalVaadinDialog extends AbstractDialog<TabularToRel
         charsetSelect.setNullSelectionAllowed(false);
         charsetSelect.setImmediate(true);
         formLayout.addComponent(charsetSelect);
+
+        this.validCsvCheckbox = new CheckBox(this.ctx.tr("dialog.validCsv"));
+        this.validCsvCheckbox.setDescription(this.ctx.tr("dialog.validCsv.description"));
+        formLayout.addComponent(this.validCsvCheckbox);
 
         return formLayout;
     }
@@ -200,6 +206,7 @@ public class TabularToRelationalVaadinDialog extends AbstractDialog<TabularToRel
         fieldDelimiterField.setValue(config.getFieldDelimiter());
         fieldSeparatorField.setValue(config.getFieldSeparator());
         parserTypeOptionGroup.setValue(config.getParserType());
+        validCsvCheckbox.setValue(config.isProcessOnlyValidCsv());
         table.removeAllItems();
         if (config.getColumnMapping() == null || config.getColumnMapping().isEmpty()) { // if config does not contain any mapping, create empty one
             // add first row
@@ -224,6 +231,7 @@ public class TabularToRelationalVaadinDialog extends AbstractDialog<TabularToRel
         config.setFieldSeparator(fieldSeparatorField.getValue());
         config.setParserType((ParserType) parserTypeOptionGroup.getValue());
         config.setDataBegginningRow(Integer.parseInt(dataBeginningRowField.getValue()));
+        config.setProcessOnlyValidCsv(this.validCsvCheckbox.getValue());
 
         List<ColumnMappingEntry> list = new ArrayList<>();
         for (Iterator i = table.getItemIds().iterator(); i.hasNext();) {

--- a/t-tabularToRelational/src/main/resources/resources.properties
+++ b/t-tabularToRelational/src/main/resources/resources.properties
@@ -1,37 +1,47 @@
-dpu.name =  t-tabularToRelational
-dpu.name.menu = t-tabularToRelational
+
+create.new.table = Creating new table.
+
+csv.cell.parse.error           = Cannot process cell. This cell value is skipped.
+csv.cell.parse.error.number    = Error in cell number: {}.
+csv.errors.invalid.input.long  = Row Nr. {0} column count ( = {1}) does not match defined header column count ( = {2})
+csv.errors.invalid.input.short = Invalid input CSV file
+
+dialog.charset                      = Charset:
+dialog.charset.description          = Charset used in input file.
+# configuration dialog
+dialog.configuration.input          = Input file configuration:
+dialog.configuration.output         = Output table configuration:
+dialog.dataBeginningRow             = Data begins at row:
+dialog.dataBeginningRow.description = Select at which row, in the source file, begins the data, you want to process. Rows before this number will be ignored.
+dialog.dataBeginningRow.restriction = Value of row needs to be positive integer number.
+dialog.fieldDelimiter               = Quote character:
+dialog.fieldDelimiter.description   = Character, which may be used to enclose values of particular fields. Double quotes are used in standard. Example: "some value 1","some value 2","some value 3".
+dialog.fieldSeparator               = Separator:
+dialog.fieldSeparator.description   = Separator of fields (columns) in CSV document. Comma is used in standard. Example: value1,value2,value3.
+dialog.parser.type                  = Filetype:
+dialog.tableName.example            = SOME_TABLE
+dialog.tablecolumn.restriction      = Column name can only begin with letter and contain letters without accents, digits or underscore.
+dialog.tablename                    = Tablename:
+dialog.tablename.description        = Name of table that will hold the parsed data.
+dialog.tablename.required           = Name of table is required.
+dialog.tablename.restriction        = Name of table can only begin with letter and contain letters without accents, digits or underscore.
+dialog.validCsv                     = Validate CSV files
+dialog.validCsv.description         = If checked, input CSV files are validated (row column counts are compared to user defined columns count) and DPU fails if CSV is not valid
 
 # business messages
-dpu.cancelled=DPU was cancelled.
-errors.dpu.failed=DPU Failed
-errors.dpu.parse.failed=Failed to parse all files.
-create.new.table=Creating new table.
-insert.file=Inserting file {0} into table.
-parsing.finished=Parsing tabular data into relational database have been completed.
-csv.cell.parse.error=Cannot process cell. This cell value is skipped.
-csv.cell.parse.error.number=Error in cell number: {}.
+dpu.cancelled = DPU was cancelled.
+dpu.name      = t-tabularToRelational
+dpu.name.menu = t-tabularToRelational
+
+errors.dpu.failed           = DPU Failed
+errors.dpu.parse.failed     = Failed to parse all files.
 errors.unsupported.encoding = Selected encoding is not supported.
 
-# configuration dialog
-dialog.configuration.input=Input file configuration\:
-dialog.configuration.output=Output table configuration\:
-dialog.parser.type = Filetype\:
-dialog.tablename=Tablename\:
-dialog.tablename.required=Name of table is required.
-dialog.tablename.description=Name of table that will hold the parsed data.
-dialog.tablename.restriction=Name of table can only begin with letter and contain letters without accents, digits or underscore.
-dialog.tablecolumn.restriction=Column name can only begin with letter and contain letters without accents, digits or underscore.
-dialog.tableName.example=SOME_TABLE
-dialog.charset=Charset\:
-dialog.charset.description=Charset used in input file.
-dialog.fieldDelimiter=Quote character\:
-dialog.fieldDelimiter.description=Character, which may be used to enclose values of particular fields. Double quotes are used in standard. Example\: "some value 1","some value 2","some value 3".
-dialog.fieldSeparator=Separator\:
-dialog.fieldSeparator.description=Separator of fields (columns) in CSV document. Comma is used in standard. Example\: value1,value2,value3.
-table.label=Mapping table\:
-table.desciption=This table contains mapping of values from input file to resulting database table.
-table.name=Column name
-table.primary.key=Composite key?
-dialog.dataBeginningRow=Data begins at row\:
-dialog.dataBeginningRow.description=Select at which row, in the source file, begins the data, you want to process. Rows before this number will be ignored.
-dialog.dataBeginningRow.restriction=Value of row needs to be positive integer number.
+insert.file = Inserting file {0} into table.
+
+parsing.finished = Parsing tabular data into relational database have been completed.
+
+table.desciption  = This table contains mapping of values from input file to resulting database table.
+table.label       = Mapping table:
+table.name        = Column name
+table.primary.key = Composite key?

--- a/t-tabularToRelational/src/main/resources/resources_sk.properties
+++ b/t-tabularToRelational/src/main/resources/resources_sk.properties
@@ -1,37 +1,47 @@
-dpu.name =  Na\u010D\u00EDtanie tabu\u013Ekov\u00FDch d\u00E1t zo s\u00FAboru
-dpu.name.menu = tabu\u013Ekov\u00E9 d\u00E1ta zo s\u00FAboru
+
+create.new.table = Vytv\u00E1ranie novej tabu\u013Eky.
+
+csv.cell.parse.error           = Nepodarilo sa spracova\u0165 bunku. Hodnota v tejto bunke bola presko\u010Den\u00E1.
+csv.cell.parse.error.number    = Chyba v bunke cislo: {}.
+csv.errors.invalid.input.long  = V riadku \u010D. {0} nes\u00FAhlas\u00ED po\u010Det st\u013Apcov ( = {1}) s po\u010Dtom st\u013Apcov v definovanej hlavi\u010Dke ( = {2})
+csv.errors.invalid.input.short = Nevalidn\u00FD vstupn\u00FD CSV s\u00FAbor
+
+dialog.charset                      = Znakov\u00E1 sada:
+dialog.charset.description          = Znakov\u00E1 sada vstupn\u00FDch s\u00FAborov. Napr. 'UTF-8'.
+dialog.configuration.input          = Konfigur\u00E1cia vstupn\u00E9ho s\u00FAboru:
+dialog.configuration.output         = Konfigur\u00E1cia v\u00FDstupnej tabu\u013Eky:
+dialog.dataBeginningRow             = D\u00E1ta za\u010D\u00EDnaj\u00FA na riadku:
+dialog.dataBeginningRow.description = Zvo\u013Ete na ktorom riadku, v zdrojovom s\u00FAbore, za\u010D\u00EDnaj\u00FA d\u00E1ta, ktor\u00E9 je potrebn\u00E9 spracova\u0165. Riadky, pred t\u00FDmto \u010D\u00EDslom bud\u00FA ignorovan\u00E9.
+dialog.dataBeginningRow.restriction = Hodnota riadku mus\u00ED by\u0165 kladn\u00E9 cel\u00E9 \u010D\u00EDslo.
+dialog.fieldDelimiter               = Znak \u00FAvodzoviek:
+dialog.fieldDelimiter.description   = Znak, ktor\u00FDm m\u00F4\u017Eu by\u0165 ohrani\u010Den\u00E9 hodnoty jednotliv\u00FDch pol\u00ED\u010Dok. \u0160tandardne sa pou\u017E\u00EDvaj\u00FA dvojit\u00E9 \u00FAvodzovky. Pr\u00EDklad: "nejaka hodnota1","nejaka hodnota2","nejaka hodnota3".
+dialog.fieldSeparator               = Oddelova\u010D:
+dialog.fieldSeparator.description   = Oddelova\u010D pol\u00ED\u010Dok (st\u013Apcov) v CSV dokumente. \u0160tandardne sa pou\u017E\u00EDva \u010Diarka. Pr\u00EDklad: hodnota1,hodnota2,hodnota3.
+dialog.parser.type                  = Typ s\u00FAboru:
+dialog.tableName.example            = NEJAKA_TABULKA
+dialog.tablecolumn.restriction      = Meno st\u013Apca m\u00F4\u017Ee za\u010D\u00EDna\u0165 len p\u00EDsmenom, a obsahova\u0165 p\u00EDsmen\u00E1 bez diakritiky, \u010D\u00EDslice a podtr\u017En\u00EDky.
+# configuration dialog
+dialog.tablename                    = N\u00E1zov tabu\u013Eky:
+dialog.tablename.description        = N\u00E1zov tabu\u013Eky, ktor\u00FD v sebe bude obsahova\u0165? na\u010D\u00EDtan\u00E9 d\u00E1ta.
+dialog.tablename.required           = N\u00E1zov tabu\u013Eky mus\u00ED by\u0165 zadan\u00FD.
+dialog.tablename.restriction        = N\u00E1zov tabu\u013Eky m\u00F4\u017Ee za\u010D\u00EDna\u0165 len p\u00EDsmenom, a obsahova\u0165 p\u00EDsmen\u00E1 bez diakritiky, \u010D\u00EDslice a podtr\u017En\u00EDky.
+dialog.validCsv                     = Validova\u0165 CSV s\u00FAbory
+dialog.validCsv.description         = Ak zvolen\u00E9, vstupn\u00E9 DPU s\u00FAbory s\u00FA validovan\u00E9 (po\u010Det st\u013Apcov v jednotliv\u00FDch riadkoch sa porovn\u00E1va s po\u010Dtom st\u013Apcov definovan\u00FDch pou\u017E\u00EDvate\u013Eom) a krok zlyh\u00E1 ak je CSV nevalidn\u00E9
 
 # business error messages
-dpu.cancelled=Spracovanie DPU bolo zru\u0161en\u00E9.
-errors.dpu.failed=Chyba DPU
-errors.dpu.parse.failed=Nepodarilo sa spracova\u0165 v\u0161etky s\u00FAbory.
-csv.cell.parse.error=Nepodarilo sa spracova\u0165 bunku. Hodnota v tejto bunke bola presko\u010Den\u00E1.
-csv.cell.parse.error.number=Chyba v bunke cislo: {}.
+dpu.cancelled = Spracovanie DPU bolo zru\u0161en\u00E9.
+dpu.name      = Na\u010D\u00EDtanie tabu\u013Ekov\u00FDch d\u00E1t zo s\u00FAboru
+dpu.name.menu = tabu\u013Ekov\u00E9 d\u00E1ta zo s\u00FAboru
+
+errors.dpu.failed           = Chyba DPU
+errors.dpu.parse.failed     = Nepodarilo sa spracova\u0165 v\u0161etky s\u00FAbory.
 errors.unsupported.encoding = Zvolen\u00E9 k\u00F3dovanie nie je podporovan\u00E9.
 
-# configuration dialog
-dialog.tablename=N\u00E1zov tabu\u013Eky\:
-dialog.tablename.required=N\u00E1zov tabu\u013Eky mus\u00ED by\u0165 zadan\u00FD.
-dialog.tablename.description=N\u00E1zov tabu\u013Eky, ktor\u00FD v sebe bude obsahova\u0165? na\u010D\u00EDtan\u00E9 d\u00E1ta.
-dialog.tablename.restriction=N\u00E1zov tabu\u013Eky m\u00F4\u017Ee za\u010D\u00EDna\u0165 len p\u00EDsmenom, a obsahova\u0165 p\u00EDsmen\u00E1 bez diakritiky, \u010D\u00EDslice a podtr\u017En\u00EDky.
-dialog.tablecolumn.restriction=Meno st\u013Apca m\u00F4\u017Ee za\u010D\u00EDna\u0165 len p\u00EDsmenom, a obsahova\u0165 p\u00EDsmen\u00E1 bez diakritiky, \u010D\u00EDslice a podtr\u017En\u00EDky.
-dialog.tableName.example=NEJAKA_TABULKA
-dialog.charset=Znakov\u00E1 sada\:
-dialog.charset.description=Znakov\u00E1 sada vstupn\u00FDch s\u00FAborov. Napr. 'UTF-8'.
-dialog.fieldDelimiter=Znak \u00FAvodzoviek\:
-dialog.fieldDelimiter.description=Znak, ktor\u00FDm m\u00F4\u017Eu by\u0165 ohrani\u010Den\u00E9 hodnoty jednotliv\u00FDch pol\u00ED\u010Dok. \u0160tandardne sa pou\u017E\u00EDvaj\u00FA dvojit\u00E9 \u00FAvodzovky. Pr\u00EDklad\: "nejaka hodnota1","nejaka hodnota2","nejaka hodnota3".
-dialog.fieldSeparator=Oddelova\u010D\:
-dialog.fieldSeparator.description=Oddelova\u010D pol\u00ED\u010Dok (st\u013Apcov) v CSV dokumente. \u0160tandardne sa pou\u017E\u00EDva \u010Diarka. Pr\u00EDklad\: hodnota1,hodnota2,hodnota3.
-table.name=Meno st\u013Apca
-table.primary.key=Kompozitn\u00FD k\u013E\u00FA\u010D?
-create.new.table=Vytv\u00E1ranie novej tabu\u013Eky.
-insert.file=Vkladanie s\u00FAboru {0} do tabu\u013Eky.
-parsing.finished=Na\u010D\u00EDtanie tabu\u013Ekov\u00FDch d\u00E1t to rela\u010Dnej datab\u00E1zy je ukon\u010Den\u00E9.
-dialog.configuration.input=Konfigur\u00E1cia vstupn\u00E9ho s\u00FAboru\:
-dialog.configuration.output=Konfigur\u00E1cia v\u00FDstupnej tabu\u013Eky\:
-dialog.parser.type = Typ s\u00FAboru\:
-table.label=Mapovacia tabu\u013Eka\:
-table.desciption=T\u00E1to tabu\u013Eka definuje mapovanie vstupn\u00FDch hodn\u00F4t zo s\u00FAboru na v\u00FDsledn\u00FA datab\u00E1zov\u00FA tabu\u013Eku.
-dialog.dataBeginningRow=D\u00E1ta za\u010D\u00EDnaj\u00FA na riadku\:
-dialog.dataBeginningRow.description=Zvo\u013Ete na ktorom riadku, v zdrojovom s\u00FAbore, za\u010D\u00EDnaj\u00FA d\u00E1ta, ktor\u00E9 je potrebn\u00E9 spracova\u0165. Riadky, pred t\u00FDmto \u010D\u00EDslom bud\u00FA ignorovan\u00E9.
-dialog.dataBeginningRow.restriction=Hodnota riadku mus\u00ED by\u0165 kladn\u00E9 cel\u00E9 \u010D\u00EDslo.
+insert.file = Vkladanie s\u00FAboru {0} do tabu\u013Eky.
+
+parsing.finished = Na\u010D\u00EDtanie tabu\u013Ekov\u00FDch d\u00E1t to rela\u010Dnej datab\u00E1zy je ukon\u010Den\u00E9.
+
+table.desciption  = T\u00E1to tabu\u013Eka definuje mapovanie vstupn\u00FDch hodn\u00F4t zo s\u00FAboru na v\u00FDsledn\u00FA datab\u00E1zov\u00FA tabu\u013Eku.
+table.label       = Mapovacia tabu\u013Eka:
+table.name        = Meno st\u013Apca
+table.primary.key = Kompozitn\u00FD k\u013E\u00FA\u010D?

--- a/t-tabularToRelational/src/test/resources/sample_invalid.csv
+++ b/t-tabularToRelational/src/test/resources/sample_invalid.csv
@@ -1,0 +1,1 @@
+﻿Názov Tovaru;Cena za kus v EUR;Počet KusovPapuče;10;3Košeľa;35Nohavice;50;12Topánky;60;10Tričko;20Tepláky;21;1Uterák;5;44Sako;100;7Kravata;45;4Vesta;32;2


### PR DESCRIPTION
T-TabularToRelational was too robust, it is able to process almost arbitrary text, not only valid CSV. Added optional check to validate input CSV files before loading them to relational tables. By default DPU works as before.

Validation checks if each row in CSV file has at least as much columns as colums count defined by the user in the column mapping setting. This should filter most of the invalid CSV files for user provided settings.

Motivation:
We had case when CKAN returned HTML response and HTTP status 200 OK when trying to download CSV file from private resource. TabularToRelational DPU was able to transform the HTML to relational table and as result we had HTML stored in datastore table in CKAN.

New configuration option added which enables CSV validation. This option is by default disabled so DPU behavior is not changed after upgrade.