### PR TITLE
Feature/simplify sparql extractor no ft

### DIFF
--- a/e-sparqlEndpoint/src/main/java/eu/unifiedviews/plugins/extractor/sparqlendpoint/RemoteRdfDataUnit.java
+++ b/e-sparqlEndpoint/src/main/java/eu/unifiedviews/plugins/extractor/sparqlendpoint/RemoteRdfDataUnit.java
@@ -1,18 +1,5 @@
 package eu.unifiedviews.plugins.extractor.sparqlendpoint;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
-
-import org.openrdf.model.URI;
-import org.openrdf.repository.RepositoryConnection;
-import org.openrdf.repository.RepositoryException;
-import org.openrdf.repository.sparql.SPARQLRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import eu.unifiedviews.dataunit.DataUnitException;
 import eu.unifiedviews.dataunit.rdf.RDFDataUnit;
 import eu.unifiedviews.dpu.DPUException;
@@ -21,6 +8,14 @@ import eu.unifiedviews.helpers.dpu.context.Context;
 import eu.unifiedviews.helpers.dpu.exec.ExecContext;
 import eu.unifiedviews.helpers.dpu.extension.Extension;
 import eu.unifiedviews.helpers.dpu.extension.ExtensionException;
+import org.openrdf.model.URI;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+import org.openrdf.repository.sparql.SPARQLRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 
 /**
  * Represents remote RDF repository in form of {@link RDFDataUnit}.
@@ -126,6 +121,7 @@ public class RemoteRdfDataUnit implements RDFDataUnit, AutoCloseable, Extension,
         if (execPoint == ExecutionPoint.POST_EXECUTE) {
             // If RdfDataUnit is not closed then call close.
             if (!closed) {
+                LOG.debug("RdfDatunit not closed, calling close()");
                 try {
                     close();
                 } catch (Exception ex) {

--- a/e-sparqlEndpoint/src/main/java/eu/unifiedviews/plugins/extractor/sparqlendpoint/SparqlEndpoint.java
+++ b/e-sparqlEndpoint/src/main/java/eu/unifiedviews/plugins/extractor/sparqlendpoint/SparqlEndpoint.java
@@ -1,21 +1,11 @@
 package eu.unifiedviews.plugins.extractor.sparqlendpoint;
 
-import org.openrdf.model.Statement;
-import org.openrdf.model.URI;
-import org.openrdf.query.GraphQuery;
-import org.openrdf.query.GraphQueryResult;
-import org.openrdf.query.QueryLanguage;
-import org.openrdf.repository.RepositoryConnection;
-
-import eu.unifiedviews.dpu.DPU;
-import eu.unifiedviews.dpu.DPUException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import eu.unifiedviews.dataunit.DataUnit;
+import eu.unifiedviews.dataunit.DataUnitException;
 import eu.unifiedviews.dataunit.rdf.RDFDataUnit;
 import eu.unifiedviews.dataunit.rdf.WritableRDFDataUnit;
+import eu.unifiedviews.dpu.DPU;
+import eu.unifiedviews.dpu.DPUException;
 import eu.unifiedviews.helpers.dataunit.DataUnitUtils;
 import eu.unifiedviews.helpers.dataunit.rdf.RdfDataUnitUtils;
 import eu.unifiedviews.helpers.dpu.config.ConfigHistory;
@@ -23,9 +13,15 @@ import eu.unifiedviews.helpers.dpu.config.migration.ConfigurationUpdate;
 import eu.unifiedviews.helpers.dpu.context.ContextUtils;
 import eu.unifiedviews.helpers.dpu.exec.AbstractDpu;
 import eu.unifiedviews.helpers.dpu.extension.ExtensionInitializer;
-import eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultTolerance;
 import eu.unifiedviews.helpers.dpu.extension.rdf.simple.WritableSimpleRdf;
 import eu.unifiedviews.plugins.extractor.rdffromsparql.RdfFromSparqlEndpointConfig_V1;
+import org.openrdf.model.Statement;
+import org.openrdf.model.URI;
+import org.openrdf.query.*;
+import org.openrdf.repository.RepositoryConnection;
+import org.openrdf.repository.RepositoryException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Main data processing unit class.
@@ -42,9 +38,6 @@ public class SparqlEndpoint extends AbstractDpu<SparqlEndpointConfig_V1> {
     @ExtensionInitializer.Init(param = "rdfOutput")
     public WritableSimpleRdf output;
 
-    @ExtensionInitializer.Init
-    public FaultTolerance faultTolerance;
-
     @ExtensionInitializer.Init(param = "eu.unifiedviews.plugins.extractor.rdffromsparql.RdfFromSparqlEndpointConfig_V1")
     public ConfigurationUpdate _ConfigurationUpdate;
 
@@ -58,16 +51,19 @@ public class SparqlEndpoint extends AbstractDpu<SparqlEndpointConfig_V1> {
 
     @Override
     protected void innerExecute() throws DPUException {
-        // Prepare output.
-        final RDFDataUnit.Entry outputEntry = faultTolerance.execute(new FaultTolerance.ActionReturn<RDFDataUnit.Entry>() {
 
-            @Override
-            public RDFDataUnit.Entry action() throws Exception {
-                return RdfDataUnitUtils.addGraph(rdfOutput, DataUnitUtils.generateSymbolicName(this.getClass()));
-            }
-        });
+        // Prepares output entry
+        LOG.info("Preparing output data entry");
+        RDFDataUnit.Entry outputEntry = null;
+        try {
+            outputEntry = RdfDataUnitUtils.addGraph(rdfOutput, DataUnitUtils.generateSymbolicName(this.getClass()));
+        } catch (DataUnitException e) {
+            LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+        }
+
         output.setOutput(outputEntry);
-        // Connect to remote repository.
+
+        LOG.info("Connecting to remote repository (to fetch the data)");
         final RemoteRdfDataUnit remote;
         try {
             remote = new RemoteRdfDataUnit(ctx.getExecMasterContext(), config.getEndpoint(), new URI[0]);
@@ -76,18 +72,81 @@ public class SparqlEndpoint extends AbstractDpu<SparqlEndpointConfig_V1> {
         } catch (ExternalError ex) {
             throw ContextUtils.dpuException(ctx, ex, "SparqlEndpoint.exec.cantConnect ");
         }
-        // Execute query.
-        faultTolerance.execute(remote, new FaultTolerance.ConnectionAction() {
 
-            @Override
-            public void action(RepositoryConnection connection) throws Exception {
-                if (config.getChunkSize() == null || config.getChunkSize() == -1) {
-                    GraphQuery query = connection.prepareGraphQuery(QueryLanguage.SPARQL, config.getQuery());
-                    LOG.info("Executing query.");
-                    GraphQueryResult result = query.evaluate();
-                    LOG.info("Storing result.");
-                    long counter = 0;
+        LOG.info("Fetching data from remote repository");
+        RepositoryConnection remoteConnection = null;
+        try {
+            remoteConnection = remote.getConnection();
+        } catch (DataUnitException e) {
+            LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+        }
+        if (config.getChunkSize() == null || config.getChunkSize() == -1) {
+            //no chunks
+            GraphQuery query = null;
+            try {
+                query = remoteConnection.prepareGraphQuery(QueryLanguage.SPARQL, config.getQuery());
+            } catch (RepositoryException e) {
+                LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+            } catch (MalformedQueryException e) {
+                LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+            }
+            try {
+                LOG.info("Executing query.");
+                GraphQueryResult result = query.evaluate();
+                LOG.info("Storing result to the working store");
+                long counter = 0;
+
+                while (result.hasNext()) {
+                    final Statement st = result.next();
+                    // Add to out output.
+                    output.add(st.getSubject(), st.getPredicate(), st.getObject());
+                    // Print info.
+                    ++counter;
+                    if (counter % 100000 == 0) {
+                        LOG.info("{} triples extracted", counter);
+                    }
+                }
+                LOG.info("Data fetched and stored from remote repository.");
+            } catch (QueryEvaluationException e) {
+                LOG.error(e.getLocalizedMessage(),e.getStackTrace());
+            }
+        } else {
+            String origQuery = config.getQuery();
+            LOG.debug("Original query: {}", origQuery);
+            boolean returnedSomeTriples = true;
+            long offset = 0;
+            long limit = config.getChunkSize();
+            long counter = 0;
+            if (QueryPagingRewriter2.hasLimit(origQuery)) {
+                ContextUtils.sendWarn(ctx, "SparqlEndpoint.exec.hasLimit", "SparqlEndpoint.exec.hasLimit");
+            }
+            if (QueryPagingRewriter2.isOrdered(origQuery)) {
+                ContextUtils.sendWarn(ctx, "SparqlEndpoint.exec.isOrdered", "SparqlEndpoint.exec.isOrdered");
+            }
+            while (returnedSomeTriples) {
+                returnedSomeTriples = false;
+                String querySlice = QueryPagingRewriter2.rewriteQuery(origQuery, limit, offset);
+                LOG.debug("Sliced query " + querySlice);
+                GraphQuery query = null;
+                try {
+                    query = remoteConnection.prepareGraphQuery(QueryLanguage.SPARQL,
+                            querySlice);
+                } catch (RepositoryException e) {
+                    LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+                } catch (MalformedQueryException e) {
+                    LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+                }
+                LOG.info("Executing query.");
+                GraphQueryResult result = null;
+                try {
+                    result = query.evaluate();
+                } catch (QueryEvaluationException e) {
+                    LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+                }
+                LOG.info("Storing result.");
+                try {
                     while (result.hasNext()) {
+                        returnedSomeTriples = true;
                         final Statement st = result.next();
                         // Add to out output.
                         output.add(st.getSubject(), st.getPredicate(), st.getObject());
@@ -97,56 +156,27 @@ public class SparqlEndpoint extends AbstractDpu<SparqlEndpointConfig_V1> {
                             LOG.info("{} triples extracted", counter);
                         }
                     }
-                } else {
-                    String origQuery = config.getQuery();
-                    LOG.debug("Original query: {}", origQuery);
-                    boolean returnedSomeTriples = true;
-                    long offset = 0;
-                    long limit = config.getChunkSize();
-                    long counter = 0;
-                    if (QueryPagingRewriter2.hasLimit(origQuery)) {
-                        ContextUtils.sendWarn(ctx, "SparqlEndpoint.exec.hasLimit", "SparqlEndpoint.exec.hasLimit");
-                    }
-                    if (QueryPagingRewriter2.isOrdered(origQuery)) {
-                        ContextUtils.sendWarn(ctx, "SparqlEndpoint.exec.isOrdered", "SparqlEndpoint.exec.isOrdered");
-                    }
-                    while (returnedSomeTriples) {
-                        returnedSomeTriples = false;
-                        String querySlice = QueryPagingRewriter2.rewriteQuery(origQuery, limit, offset);
-                        LOG.debug("Sliced query " + querySlice);
-                        GraphQuery query = connection.prepareGraphQuery(QueryLanguage.SPARQL,
-                                querySlice);
-                        LOG.info("Executing query.");
-                        GraphQueryResult result = query.evaluate();
-                        LOG.info("Storing result.");
-                        while (result.hasNext()) {
-                            returnedSomeTriples = true;
-                            final Statement st = result.next();
-                            // Add to out output.
-                            output.add(st.getSubject(), st.getPredicate(), st.getObject());
-                            // Print info.
-                            ++counter;
-                            if (counter % 100000 == 0) {
-                                LOG.info("{} triples extracted", counter);
-                            }
-                        }
-                        offset += limit;
-                    }
+                } catch (QueryEvaluationException e) {
+                    LOG.error(e.getLocalizedMessage(), e.getStackTrace());
                 }
+                offset += limit;
             }
-        });
+        }
+
         LOG.info("Flushing buffers.");
         output.flushBuffer();
 
         LOG.info("Get size of the extracted data");
-        faultTolerance.execute(rdfOutput, new FaultTolerance.ConnectionAction() {
+        long size = 0;
+        try {
+            size = rdfOutput.getConnection().size(outputEntry.getDataGraphURI());
+        } catch (RepositoryException e) {
+            LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+        } catch (DataUnitException e) {
+            LOG.error(e.getLocalizedMessage(), e.getStackTrace());
+        }
+        ContextUtils.sendShortInfo(ctx, "SparqlEndpoint.exec.extracted", size);
 
-            @Override
-            public void action(RepositoryConnection connection) throws Exception {
-                long size = connection.size(outputEntry.getDataGraphURI());
-                ContextUtils.sendShortInfo(ctx, "SparqlEndpoint.exec.extracted", size);
-            }
-        });
 
     }
 }

--- a/t-rdfToFiles/src/main/java/eu/unifiedviews/plugins/transformer/rdftofiles/RdfToFiles.java
+++ b/t-rdfToFiles/src/main/java/eu/unifiedviews/plugins/transformer/rdftofiles/RdfToFiles.java
@@ -1,11 +1,24 @@
 package eu.unifiedviews.plugins.transformer.rdftofiles;
 
 import eu.unifiedviews.dataunit.DataUnit;
+import eu.unifiedviews.dataunit.files.FilesDataUnit;
 import eu.unifiedviews.dataunit.files.WritableFilesDataUnit;
 import eu.unifiedviews.dataunit.rdf.RDFDataUnit;
 import eu.unifiedviews.dpu.DPU;
+import eu.unifiedviews.dpu.DPUContext.MessageType;
 import eu.unifiedviews.dpu.DPUException;
-
+import eu.unifiedviews.helpers.dataunit.files.FilesDataUnitUtils;
+import eu.unifiedviews.helpers.dataunit.files.FilesVocabulary;
+import eu.unifiedviews.helpers.dataunit.metadata.MetadataUtils;
+import eu.unifiedviews.helpers.dataunit.rdf.RdfDataUnitUtils;
+import eu.unifiedviews.helpers.dpu.config.ConfigHistory;
+import eu.unifiedviews.helpers.dpu.config.migration.ConfigurationUpdate;
+import eu.unifiedviews.helpers.dpu.context.ContextUtils;
+import eu.unifiedviews.helpers.dpu.exec.AbstractDpu;
+import eu.unifiedviews.helpers.dpu.extension.ExtensionInitializer;
+import eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultTolerance;
+import eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultToleranceUtils;
+import eu.unifiedviews.helpers.dpu.extension.rdf.RdfConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.openrdf.model.URI;
 import org.openrdf.repository.RepositoryConnection;
@@ -21,21 +34,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 import java.util.List;
-
-import eu.unifiedviews.dataunit.files.FilesDataUnit;
-import eu.unifiedviews.dpu.DPUContext.MessageType;
-import eu.unifiedviews.helpers.dataunit.files.FilesDataUnitUtils;
-import eu.unifiedviews.helpers.dataunit.files.FilesVocabulary;
-import eu.unifiedviews.helpers.dataunit.metadata.MetadataUtils;
-import eu.unifiedviews.helpers.dataunit.rdf.RdfDataUnitUtils;
-import eu.unifiedviews.helpers.dpu.config.ConfigHistory;
-import eu.unifiedviews.helpers.dpu.config.migration.ConfigurationUpdate;
-import eu.unifiedviews.helpers.dpu.context.ContextUtils;
-import eu.unifiedviews.helpers.dpu.exec.AbstractDpu;
-import eu.unifiedviews.helpers.dpu.extension.ExtensionInitializer;
-import eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultTolerance;
-import eu.unifiedviews.helpers.dpu.extension.faulttolerance.FaultToleranceUtils;
-import eu.unifiedviews.helpers.dpu.extension.rdf.RdfConfiguration;
 
 @DPU.AsTransformer
 public class RdfToFiles extends AbstractDpu<RdfToFilesConfig_V2> {
@@ -149,7 +147,7 @@ public class RdfToFiles extends AbstractDpu<RdfToFilesConfig_V2> {
     /**
      * Check if file graph should be generated and if so, then generate new graph file.
      * 
-     * @param graph
+     * @param rdfFile
      * @param graphName
      *            Name of the graph, that will be written into .graph file.
      * @throws DPUException


### PR DESCRIPTION
TODO: t-sparqlUpdate - useDataset() - currently disabled as it is not supported? by Marklogic. Do it in a better way so that it is automatically disabled when marklogic is selected?

Check also other locations of useDataset() as this is also an issue when metadata is produced - there is also Dataset used and it is not taken into account by ML and as a resutl, data is written to default graph and not to the desired graph. See also: https://grips.semantic-web.at/display/UNVI/Marklogic+Working+Store